### PR TITLE
Fix Circom compile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,4 +52,4 @@ jobs:
 
       # ─── Circom compilation ──────────────────────────────────────────────
       - name: Compile Circom circuits
-        run: npx circom circuits/eligibility/eligibility.circom --r1cs --wasm --sym
+        run: npx -y circom2 circuits/eligibility/eligibility.circom --r1cs --wasm --sym

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Toting Example
+
+This repository includes example Circom circuits and minimal setup scripts. To build the circuits you need **Circom 2**.
+
+Run compilation with:
+
+```bash
+npx -y circom2 circuits/eligibility/eligibility.circom --r1cs --wasm --sym
+```
+
+Using plain `npx circom` installs the legacy Circom 1 package, which fails on `pragma circom 2.x`. Always invoke Circom 2 via the `circom2` package.
+
+

--- a/init.sh
+++ b/init.sh
@@ -26,7 +26,7 @@ jobs:
     - run: npm i -g yarn
     - run: yarn install --immutable
     - run: yarn --cwd packages/frontend type-check
-    - run: npx circom circuits/eligibility/eligibility.circom --r1cs --wasm --sym
+    - run: npx -y circom2 circuits/eligibility/eligibility.circom --r1cs --wasm --sym
 YAML
 
 cat > contracts/WalletFactory.sol <<'SOL'


### PR DESCRIPTION
## Summary
- pin Circom 2 compiler in CI and init script using the `circom2` npm package
- document how to compile Circom 2 in README

## Testing
- `npm test` *(fails: missing project config)*
- `npx -y circom2 --version`

------
https://chatgpt.com/codex/tasks/task_e_683f4e498a648327baf10793b20c26a5