### PR TITLE
Add light/dark theme toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ node_modules
 res.txt
 .yarn
 .yarnrc.yml
+packages/frontend/.next
+packages/frontend/package-lock.json

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -12,7 +12,9 @@
     "ethers": "^5",
     "next": "^13.0.0",
     "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react-dom": "^18.0.0",
+    "@headlessui/react": "^1.7.16",
+    "next-themes": "^0.2.1"
   },
   "devDependencies": {
     "@types/node": "^18.0.0",

--- a/packages/frontend/src/components/ThemeToggle.tsx
+++ b/packages/frontend/src/components/ThemeToggle.tsx
@@ -1,0 +1,24 @@
+import { Switch } from '@headlessui/react';
+import { useTheme } from 'next-themes';
+import { useEffect, useState } from 'react';
+
+export default function ThemeToggle() {
+  const { resolvedTheme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+
+  if (!mounted) return null;
+
+  const enabled = resolvedTheme === 'dark';
+
+  return (
+    <Switch
+      checked={enabled}
+      onChange={() => setTheme(enabled ? 'light' : 'dark')}
+      className={`switch ${enabled ? 'on' : 'off'}`}
+    >
+      <span />
+    </Switch>
+  );
+}

--- a/packages/frontend/src/pages/_app.tsx
+++ b/packages/frontend/src/pages/_app.tsx
@@ -1,0 +1,11 @@
+import type { AppProps } from 'next/app';
+import { ThemeProvider } from 'next-themes';
+import '../styles/globals.css';
+
+export default function MyApp({ Component, pageProps }: AppProps) {
+  return (
+    <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+      <Component {...pageProps} />
+    </ThemeProvider>
+  );
+}

--- a/packages/frontend/src/pages/index.jsx
+++ b/packages/frontend/src/pages/index.jsx
@@ -1,6 +1,9 @@
+import ThemeToggle from '../components/ThemeToggle';
+
 export default function Home() {
   return (
-    <main style={{ display:'flex',alignItems:'center',justifyContent:'center',height:'100vh' }}>
+    <main style={{ display:'flex',alignItems:'center',justifyContent:'center',height:'100vh', gap:'1rem' }}>
+      <ThemeToggle />
       <a href="http://localhost:8000/auth/initiate">Log in with eID</a>
     </main>
   )

--- a/packages/frontend/src/styles/globals.css
+++ b/packages/frontend/src/styles/globals.css
@@ -1,0 +1,43 @@
+:root {
+  --bg: #ffffff;
+  --text: #000000;
+}
+.dark {
+  --bg: #000000;
+  --text: #ffffff;
+}
+body {
+  background-color: var(--bg);
+  color: var(--text);
+  transition: background-color 0.2s, color 0.2s;
+}
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 42px;
+  height: 24px;
+  border-radius: 9999px;
+  cursor: pointer;
+}
+.switch span {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 20px;
+  height: 20px;
+  background: #fff;
+  border-radius: 9999px;
+  transition: transform 0.2s;
+}
+.switch.on {
+  background: #2563eb;
+}
+.switch.on span {
+  transform: translateX(18px);
+}
+.switch.off {
+  background: #e5e7eb;
+}
+.switch.off span {
+  transform: translateX(0px);
+}


### PR DESCRIPTION
## Summary
- add next-themes and headlessui dependencies
- implement `ThemeToggle` component and styles
- wire up theme provider via custom `_app` page
- expose toggle on the home page
- ignore Next.js build output

## Testing
- `npm run type-check` in `packages/frontend`
- `npm run build` in `packages/frontend`

------
https://chatgpt.com/codex/tasks/task_e_683fcfc4e00483278a5221821a988104