### PR TITLE
Add gas snapshot diff in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions: write-all
     steps:
       - name: Checkout code (with submodules)
         uses: actions/checkout@v4
@@ -37,6 +38,17 @@ jobs:
         with:
           name: gas-report
           path: gas-report.txt
+
+      - name: Generate gas snapshot diff
+        uses: atarpara/foundry-snapshot-diff@v0.8
+        id: gas_diff
+
+      - name: Comment gas delta
+        if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          delete: ${{ !steps.gas_diff.outputs.markdown }}
+          message: ${{ steps.gas_diff.outputs.markdown }}
 
       # ─── Frontend type-check ──────────────────────────────────────────────
       - name: Setup Node.js


### PR DESCRIPTION
## Summary
- add `foundry-snapshot-diff` action and comment gas delta on PRs

## Testing
- `npm test`
- `npm run build`
- `curl https://foundry.paradigm.xyz | bash` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_683fda14c97c832785939d7a6d067346