### PR TITLE
Fix CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,4 +30,3 @@ jobs:
       - uses: github/codeql-action/analyze@v3
         with:
           category: "/language:${{ matrix.language }}"
-          fail-on-severity: high


### PR DESCRIPTION
## Summary
- remove invalid `fail-on-severity` input from CodeQL workflow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683fe0320048832790614cdc3eddd672