### PR TITLE
Add Docker compose setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
 FROM python:3.11-slim
+RUN apt-get update && apt-get install -y curl gnupg \
+    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY services/orchestrator /app/orchestrator
-RUN pip install web3 requests
+RUN pip install web3 requests && npm install -g snarkjs
 CMD ["python", "/app/orchestrator/main.py"]

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY packages/backend /app/packages/backend
+RUN pip install fastapi uvicorn python-jose[cryptography] httpx
+EXPOSE 8000
+CMD ["uvicorn","packages.backend.main:app","--host","0.0.0.0","--port","8000"]

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,0 +1,18 @@
+FROM node:20-alpine AS deps
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY packages/frontend ./packages/frontend
+RUN npm run --prefix packages/frontend build
+
+FROM node:20-alpine
+WORKDIR /app
+COPY --from=build /app/node_modules ./node_modules
+COPY --from=build /app/packages/frontend ./packages/frontend
+ENV NODE_ENV=production
+EXPOSE 3000
+CMD ["npm","run","--prefix","packages/frontend","start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   anvil:
     image: ghcr.io/foundry-rs/foundry:latest
-    user: "0"               # ← run as root so the container can start
+    user: "0"
     command: ["anvil","--host","0.0.0.0","-m","auto"]
     ports:
       - "8545:8545"
@@ -17,9 +17,66 @@ services:
       POSTGRES_PASSWORD: pass
     ports:
       - "5432:5432"
-  
+
   solana:
     image: solanalabs/solana:v1.18.3
     command: ["solana-test-validator", "--quiet"]
     ports:
       - "8899:8899"
+
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile.backend
+    environment:
+      GRAO_BASE_URL: ${GRAO_BASE_URL:-https://demo-oauth.example}
+      GRAO_CLIENT_ID: ${GRAO_CLIENT_ID:-test-client}
+      GRAO_CLIENT_SECRET: ${GRAO_CLIENT_SECRET:-test-secret}
+      GRAO_REDIRECT_URI: ${GRAO_REDIRECT_URI:-http://localhost:3000/callback}
+    ports:
+      - "8000:8000"
+    depends_on:
+      - db
+
+  frontend:
+    build:
+      context: .
+      dockerfile: Dockerfile.frontend
+    environment:
+      NEXT_PUBLIC_ENTRYPOINT: ${NEXT_PUBLIC_ENTRYPOINT:-0xYourEntryPointAddress}
+      NEXT_PUBLIC_WALLET_FACTORY: ${NEXT_PUBLIC_WALLET_FACTORY:-0xYourFactoryAddress}
+      NEXT_PUBLIC_ELECTION_MANAGER: ${NEXT_PUBLIC_ELECTION_MANAGER:-0x5FbDB2315678afecb367f032d93F642f64180aa3}
+      NEXT_PUBLIC_BUNDLER_URL: ${NEXT_PUBLIC_BUNDLER_URL:-http://localhost:3001}
+    ports:
+      - "3000:3000"
+    depends_on:
+      - backend
+
+  orchestrator:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      EVM_RPC: http://anvil:8545
+      ELECTION_MANAGER: ${ELECTION_MANAGER:-0x0000000000000000000000000000000000000000}
+      ORCHESTRATOR_KEY: ${ORCHESTRATOR_KEY:-0x0000000000000000000000000000000000000000000000000000000000000000}
+    volumes:
+      - ./circuits:/app/circuits
+    depends_on:
+      - anvil
+
+  relay:
+    build:
+      context: .
+      dockerfile: services/relay-daemon/Dockerfile
+    environment:
+      EVM_RPC: http://anvil:8545
+      SOLANA_RPC: http://solana:8899
+      POSTGRES_URL: postgres://postgres:pass@db:5432/postgres
+      ELECTION_MANAGER: ${ELECTION_MANAGER:-0x0000000000000000000000000000000000000000}
+      SOLANA_BRIDGE_SK: ${SOLANA_BRIDGE_SK:-[]}
+    ports:
+      - "9300:9300"
+    depends_on:
+      - db
+      - solana

--- a/docs/handbook/README.md
+++ b/docs/handbook/README.md
@@ -4,13 +4,15 @@ This guide covers running services, debugging contracts and regenerating ZK proo
 
 ## Running Services
 
-Use Docker Compose to launch all backend services:
+Use Docker Compose to launch the full stack (frontend, backend,
+proof orchestrator and relay):
 
 ```bash
 docker-compose up -d
 ```
 
-The API will be available on `http://localhost:3000` and Postgres on `localhost:5432`.
+The frontend will be available on `http://localhost:3000`, the API on
+`http://localhost:8000` and Postgres on `localhost:5432`.
 
 ## Debugging Contracts
 

--- a/docs/local_dev_cookbook.md
+++ b/docs/local_dev_cookbook.md
@@ -5,7 +5,7 @@
 ```bash
 git clone <repo>
 cd toting
-just up
+docker-compose up -d
 # wait 60 s
 open http://localhost:3000
 ```

--- a/services/relay-daemon/Dockerfile
+++ b/services/relay-daemon/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY services/relay-daemon ./services/relay-daemon
+COPY solana-programs/election/target/idl ./solana-programs/election/target/idl
+RUN npx tsc -p services/relay-daemon
+CMD ["node","services/relay-daemon/dist/index.js"]


### PR DESCRIPTION
## Summary
- add Dockerfiles for backend, frontend and relay daemon
- extend orchestrator image to include snarkjs
- orchestrate services with docker-compose
- document running services via Docker

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6840281b9e488327a79832e350f1f53d