### PR TITLE
Improve Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,28 @@
+# Exclude version control and build artifacts
+.git
+**/node_modules
+.yarn
+.yarnrc.yml
+
+# Frontend build output
+packages/frontend/.next
+packages/frontend/package-lock.json
+packages/frontend/node_modules
+
+# Python virtual envs
 packages/backend/.venv
+
+# Local build caches and artifacts
+out
+cache
+broadcast
+proofs
+
+# Generic compiled output
+*.r1cs
+*.wasm
+*.sym
+
+
+# Solana build output
+solana-programs/**/target

--- a/docs/local_dev_cookbook.md
+++ b/docs/local_dev_cookbook.md
@@ -5,7 +5,10 @@
 ```bash
 git clone <repo>
 cd toting
+# Build images and start services
 docker-compose up -d
 # wait 60 s
 open http://localhost:3000
 ```
+
+Docker builds rely on `.dockerignore` to keep contexts small. If you add large directories make sure they're excluded to avoid build failures.


### PR DESCRIPTION
## Summary
- reduce context sent to Docker daemon via `.dockerignore`
- document the importance of `.dockerignore` during local development

## Testing
- `yarn --version`


------
https://chatgpt.com/codex/tasks/task_e_68407c9b5300832786b62b14851e37c2