### PR TITLE
Implement upgradeable election manager and typed ballots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,6 @@
 # Changelog
+
+## [Unreleased]
+### Added
+- `ElectionManagerV2` upgradeable via UUPS proxy.
+- `submitTypedBallot` EIP-712 support in `QVManager`.

--- a/contracts/ElectionManagerV2.sol
+++ b/contracts/ElectionManagerV2.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {UUPSUpgradeable} from "openzeppelin-contracts/contracts/proxy/utils/UUPSUpgradeable.sol";
+import {Initializable} from "openzeppelin-contracts/contracts/proxy/utils/Initializable.sol";
+import {OwnableUpgradeable} from "./utils/OwnableUpgradeable.sol";
+import "./TallyVerifier.sol";
+
+interface IMACI {
+    function publishMessage(bytes calldata) external;
+}
+
+/// @title Upgradeable ElectionManager
+/// @notice Version 2 of ElectionManager using UUPS proxy pattern
+contract ElectionManagerV2 is Initializable, UUPSUpgradeable, OwnableUpgradeable {
+    IMACI public maci;
+    TallyVerifier public tallyVerifier;
+    bool public tallied;
+
+    struct Election {
+        uint256 start;
+        uint256 end;
+    }
+
+    mapping(uint256 => Election) public elections;
+    uint256 public nextId;
+
+    /// @dev initializer replaces constructor for upgradeable contracts
+    function initialize(IMACI _maci) public initializer {
+        __Ownable_init(msg.sender);
+        maci = _maci;
+        tallyVerifier = TallyVerifier(address(0));
+    }
+
+    modifier onlyDuringElection(uint256 id) {
+        Election memory e = elections[id];
+        require(block.number >= e.start && block.number <= e.end, "closed");
+        _;
+    }
+
+    function createElection(bytes32 meta) external onlyOwner {
+        elections[nextId] = Election(block.number, block.number + 7200);
+        emit ElectionCreated(nextId, meta);
+        nextId++;
+    }
+
+    function enqueueMessage(
+        uint256 id,
+        uint256 vote,
+        uint256 nonce,
+        bytes calldata vcProof
+    ) external onlyDuringElection(id) {
+        maci.publishMessage(abi.encode(msg.sender, vote, nonce, vcProof));
+    }
+
+    function tallyVotes(
+        uint256[2] calldata a,
+        uint256[2][2] calldata b,
+        uint256[2] calldata c,
+        uint256[7] calldata pubSignals
+    ) external onlyOwner {
+        require(!tallied, "already tallied");
+        require(tallyVerifier.verifyProof(a, b, c, pubSignals), "invalid tally proof");
+        emit Tally(pubSignals[0], pubSignals[1]);
+        tallied = true;
+    }
+
+    event ElectionCreated(uint256 id, bytes32 meta);
+    event Tally(uint256 A, uint256 B);
+
+    function _authorizeUpgrade(address) internal override onlyOwner {}
+}

--- a/contracts/QVManager.sol
+++ b/contracts/QVManager.sol
@@ -6,15 +6,27 @@ import "./ElectionManager.sol";
 
 /// @title Manager for Quadratic Voting ballots
 /// @notice Verifies private credit proofs and forwards encrypted ballots to MACI
-contract QVManager {
+import {EIP712} from "openzeppelin-contracts/contracts/utils/cryptography/EIP712.sol";
+import {ECDSA} from "openzeppelin-contracts/contracts/utils/cryptography/ECDSA.sol";
+
+contract QVManager is EIP712 {
     IMACI public immutable maci;
     QVVerifier public qvVerifier;
 
+    bytes32 private constant BALLOT_TYPEHASH = keccak256("Ballot(bytes32 ballotHash)");
+
     event BallotSubmitted(address indexed voter, bytes encryptedBallot);
 
-    constructor(IMACI _maci, QVVerifier _verifier) {
+    constructor(IMACI _maci, QVVerifier _verifier)
+        EIP712("QuadraticVote", "1")
+    {
         maci = _maci;
         qvVerifier = _verifier;
+    }
+
+    /// @dev helper exposed for testing
+    function hashTypedDataV4(bytes32 s) external view returns (bytes32) {
+        return _hashTypedDataV4(s);
     }
 
     /// @notice Submit an encrypted ballot after proving correct voice-credit allocation
@@ -29,6 +41,28 @@ contract QVManager {
             qvVerifier.verifyProof(a, b, c, pubSignals),
             "invalid voice credit proof"
         );
+        maci.publishMessage(encryptedBallot);
+        emit BallotSubmitted(msg.sender, encryptedBallot);
+    }
+
+    /// @notice Submit a typed ballot signed using EIP-712
+    function submitTypedBallot(
+        uint256[2] calldata a,
+        uint256[2][2] calldata b,
+        uint256[2] calldata c,
+        uint256[7] calldata pubSignals,
+        bytes calldata encryptedBallot,
+        bytes calldata signature
+    ) external {
+        require(
+            qvVerifier.verifyProof(a, b, c, pubSignals),
+            "invalid voice credit proof"
+        );
+        bytes32 digest = _hashTypedDataV4(
+            keccak256(abi.encode(BALLOT_TYPEHASH, keccak256(encryptedBallot)))
+        );
+        address signer = ECDSA.recover(digest, signature);
+        require(signer == msg.sender, "bad sig");
         maci.publishMessage(encryptedBallot);
         emit BallotSubmitted(msg.sender, encryptedBallot);
     }

--- a/contracts/utils/OwnableUpgradeable.sol
+++ b/contracts/utils/OwnableUpgradeable.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Initializable} from "openzeppelin-contracts/contracts/proxy/utils/Initializable.sol";
+
+/// @title Minimal OwnableUpgradeable
+/// @notice Simplified version of OpenZeppelin's OwnableUpgradeable for demos
+abstract contract OwnableUpgradeable is Initializable {
+    address private _owner;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    modifier onlyOwner() {
+        require(msg.sender == _owner, "not owner");
+        _;
+    }
+
+    function __Ownable_init(address initialOwner) internal initializer {
+        require(initialOwner != address(0), "owner zero");
+        _owner = initialOwner;
+        emit OwnershipTransferred(address(0), initialOwner);
+    }
+
+    function owner() public view returns (address) {
+        return _owner;
+    }
+
+    function transferOwnership(address newOwner) public onlyOwner {
+        require(newOwner != address(0), "owner zero");
+        emit OwnershipTransferred(_owner, newOwner);
+        _owner = newOwner;
+    }
+}

--- a/test/ElectionManagerUpgrade.t.sol
+++ b/test/ElectionManagerUpgrade.t.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import "../contracts/ElectionManagerV2.sol";
+import "openzeppelin-contracts/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+contract ElectionManagerUpgradeTest is Test {
+    ElectionManagerV2 impl;
+    ElectionManagerV2 newImpl;
+    ElectionManagerV2 proxyEm;
+
+    function setUp() public {
+        impl = new ElectionManagerV2();
+        bytes memory data = abi.encodeCall(ElectionManagerV2.initialize, (IMACI(address(0))));
+        ERC1967Proxy proxy = new ERC1967Proxy(address(impl), data);
+        proxyEm = ElectionManagerV2(address(proxy));
+        newImpl = new ElectionManagerV2();
+    }
+
+    function testUpgrade() public {
+        // owner is address(this) from initialization
+        proxyEm.upgradeTo(address(newImpl));
+        assertEq(proxyEm.owner(), address(this));
+    }
+}

--- a/test/QVManagerTyped.t.sol
+++ b/test/QVManagerTyped.t.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import "../contracts/QVManager.sol";
+
+contract QVVerifierStub is QVVerifier {
+    function verifyProof(
+        uint256[2] calldata,
+        uint256[2][2] calldata,
+        uint256[2] calldata,
+        uint256[7] calldata
+    ) public pure override returns (bool) {
+        return true;
+    }
+}
+
+contract MACIStub is IMACI {
+    event Message(bytes data);
+    function publishMessage(bytes calldata data) external override {
+        emit Message(data);
+    }
+}
+
+contract QVManagerTypedTest is Test {
+    QVManager manager;
+    QVVerifierStub verifier;
+    MACIStub maci;
+
+    function setUp() public {
+        verifier = new QVVerifierStub();
+        maci = new MACIStub();
+        manager = new QVManager(IMACI(maci), QVVerifier(address(verifier)));
+    }
+
+    function testSubmitTypedBallot() public {
+        uint256[2] memory a;
+        uint256[2][2] memory b;
+        uint256[2] memory c;
+        uint256[7] memory inputs;
+        bytes memory ballot = hex"deadbeef";
+        bytes32 digest = manager.hashTypedDataV4(keccak256(abi.encode(
+            keccak256("Ballot(bytes32 ballotHash)"),
+            keccak256(ballot)
+        )));
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(1, digest);
+        bytes memory sig = abi.encodePacked(r, s, v);
+        vm.prank(vm.addr(1));
+        manager.submitTypedBallot(a, b, c, inputs, ballot, sig);
+    }
+}


### PR DESCRIPTION
## Summary
- make `ElectionManagerV2` upgradeable with a UUPS proxy
- expose minimal `OwnableUpgradeable`
- add EIP-712 typed ballot submission to `QVManager`
- add tests for upgrade logic and typed ballots
- document these additions in `CHANGELOG`

## Testing
- `forge test` *(fails: bash: forge: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68408f0d4fe88327af6ee72a005e9946