### PR TITLE
Add backend mock OAuth login

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ Using plain `npx circom` installs the legacy Circom 1 package, which fails on `
 
 See [docs/handbook](docs/handbook/README.md) for instructions on running services and regenerating proofs.
 
+The backend exposes a simple mock OAuth login for local testing. By default
+`docker-compose` starts the API with `USE_REAL_OAUTH=false`, serving a minimal
+form at `/auth/initiate` that lets you enter an email. Set
+`USE_REAL_OAUTH=true` to redirect to the configured `GRAO_BASE_URL` instead.
+
 ## Design Deep-Dive Videos
 
 - [Circuits Overview](https://www.loom.com/share/circuits-demo)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       GRAO_CLIENT_ID: ${GRAO_CLIENT_ID:-test-client}
       GRAO_CLIENT_SECRET: ${GRAO_CLIENT_SECRET:-test-secret}
       GRAO_REDIRECT_URI: ${GRAO_REDIRECT_URI:-http://localhost:3000/callback}
+      USE_REAL_OAUTH: ${USE_REAL_OAUTH:-false}
     ports:
       - "8000:8000"
     depends_on:

--- a/packages/backend/main.py
+++ b/packages/backend/main.py
@@ -1,9 +1,10 @@
 from fastapi import FastAPI, HTTPException, Depends
-from fastapi.responses import RedirectResponse
+from fastapi.responses import RedirectResponse, HTMLResponse
 from sqlalchemy.orm import Session
 from jose import jwt
 import httpx
 import os
+from typing import Optional
 
 from .db import SessionLocal, Base, engine, Election
 from .schemas import ElectionSchema
@@ -22,26 +23,47 @@ def get_db():
     finally:
         db.close()
 
-# OAuth2 config (real GRAO or fallback to dummy)
+# OAuth2 config (real GRAO or fallback to a mock login form)
 IDP_BASE = os.getenv("GRAO_BASE_URL", "https://demo-oauth.example")
 CLIENT_ID = os.getenv("GRAO_CLIENT_ID", "test-client")
 CLIENT_SEC = os.getenv("GRAO_CLIENT_SECRET", "test-secret")
 REDIRECT = os.getenv("GRAO_REDIRECT_URI", "http://localhost:3000/callback")
+USE_REAL_OAUTH = os.getenv("USE_REAL_OAUTH", "false").lower() in ("1", "true")
 
 @app.get("/auth/initiate")
 def initiate():
-    url = (
-        f"{IDP_BASE}/authorize?"
-        f"response_type=code&client_id={CLIENT_ID}"
-        f"&redirect_uri={REDIRECT}&scope=openid email"
-    )
-    return RedirectResponse(url)
+    if USE_REAL_OAUTH:
+        url = (
+            f"{IDP_BASE}/authorize?"
+            f"response_type=code&client_id={CLIENT_ID}"
+            f"&redirect_uri={REDIRECT}&scope=openid email"
+        )
+        return RedirectResponse(url)
+
+    html = """
+    <html>
+      <body>
+        <h1>Mock Login</h1>
+        <form action='/auth/callback' method='get'>
+          <label>Email: <input type='text' name='user' value='tester@example.com'></label>
+          <button type='submit'>Login</button>
+        </form>
+      </body>
+    </html>
+    """
+    return HTMLResponse(html)
 
 @app.get("/auth/callback")
-async def callback(code: str):
-    """Exchange code for a (dummy) ID token."""
-    # For the smoke test we still mint a fake JWT
-    fake_jwt = "ey.fake.base64"
+async def callback(code: Optional[str] = None, user: Optional[str] = None):
+    """Exchange code for a (dummy) ID token or handle mock logins."""
+    if USE_REAL_OAUTH:
+        # For the smoke test we still mint a fake JWT
+        fake_jwt = "ey.fake.base64"
+        return {"id_token": fake_jwt, "eligibility": True}
+
+    email = user or "tester@example.com"
+    claims = {"email": email}
+    fake_jwt = jwt.encode(claims, CLIENT_SEC, algorithm="HS256")
     return {"id_token": fake_jwt, "eligibility": True}
 
 @app.get("/elections", response_model=list[ElectionSchema])


### PR DESCRIPTION
## Summary
- allow mocked login instead of redirecting to demo-oauth
- wire `USE_REAL_OAUTH` env var into docker-compose
- document mock login in README

## Testing
- `yarn test` *(fails: tsc help output)*

------
https://chatgpt.com/codex/tasks/task_e_6840965291fc8327b3612bfec9d71b6f