### PR TITLE
Add frontend auth and election pages

### DIFF
--- a/packages/frontend/src/components/NavBar.tsx
+++ b/packages/frontend/src/components/NavBar.tsx
@@ -1,0 +1,17 @@
+import Link from 'next/link';
+import { useAuth } from '../lib/AuthProvider';
+
+export default function NavBar() {
+  const { isLoggedIn, logout } = useAuth();
+  return (
+    <nav style={{display:'flex',gap:'1rem',padding:'1rem'}}>
+      <Link href="/">Home</Link>
+      {isLoggedIn && <Link href="/dashboard">Dashboard</Link>}
+      {isLoggedIn ? (
+        <button onClick={logout}>Logout</button>
+      ) : (
+        <a href="http://localhost:8000/auth/initiate">Log in with eID</a>
+      )}
+    </nav>
+  );
+}

--- a/packages/frontend/src/components/withAuth.tsx
+++ b/packages/frontend/src/components/withAuth.tsx
@@ -1,0 +1,15 @@
+import { useRouter } from 'next/router';
+import { useAuth } from '../lib/AuthProvider';
+import { useEffect } from 'react';
+
+export default function withAuth(Component: React.ComponentType<any>): React.FC<any> {
+  return function Protected(props: any) {
+    const { isLoggedIn } = useAuth();
+    const router = useRouter();
+    useEffect(() => {
+      if (!isLoggedIn) router.replace('/');
+    }, [isLoggedIn]);
+    if (!isLoggedIn) return null;
+    return <Component {...props} />;
+  };
+}

--- a/packages/frontend/src/lib/AuthProvider.tsx
+++ b/packages/frontend/src/lib/AuthProvider.tsx
@@ -1,0 +1,79 @@
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+
+interface AuthContextValue {
+  token: string | null;
+  eligibility: boolean;
+  isLoggedIn: boolean;
+  login: (token: string, eligibility: boolean) => void;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextValue>({
+  token: null,
+  eligibility: false,
+  isLoggedIn: false,
+  login: () => {},
+  logout: () => {},
+});
+
+function decodePayload(token: string): any {
+  try {
+    const base64 = token.split('.')[1];
+    const json = atob(base64.replace(/-/g, '+').replace(/_/g, '/'));
+    return JSON.parse(json);
+  } catch {
+    return null;
+  }
+}
+
+function tokenExpired(token: string): boolean {
+  const payload = decodePayload(token);
+  if (payload && payload.exp) {
+    return Date.now() / 1000 > payload.exp;
+  }
+  return false;
+}
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [token, setToken] = useState<string | null>(null);
+  const [eligibility, setEligibility] = useState<boolean>(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('id_token');
+    if (stored && !tokenExpired(stored)) {
+      setToken(stored);
+      setEligibility(localStorage.getItem('eligibility') === 'true');
+    } else {
+      localStorage.removeItem('id_token');
+      localStorage.removeItem('eligibility');
+    }
+  }, []);
+
+  const login = (tok: string, elig: boolean) => {
+    setToken(tok);
+    setEligibility(elig);
+    localStorage.setItem('id_token', tok);
+    localStorage.setItem('eligibility', String(elig));
+  };
+
+  const logout = () => {
+    setToken(null);
+    setEligibility(false);
+    localStorage.removeItem('id_token');
+    localStorage.removeItem('eligibility');
+    if (typeof window !== 'undefined') {
+      window.location.href = '/';
+    }
+  };
+
+  return (
+    <AuthContext.Provider value={{ token, eligibility, isLoggedIn: !!token, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  return useContext(AuthContext);
+}
+

--- a/packages/frontend/src/pages/_app.tsx
+++ b/packages/frontend/src/pages/_app.tsx
@@ -1,11 +1,14 @@
 import type { AppProps } from 'next/app';
 import { ThemeProvider } from 'next-themes';
 import '../styles/globals.css';
+import { AuthProvider } from '../lib/AuthProvider';
 
 export default function MyApp({ Component, pageProps }: AppProps) {
   return (
     <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-      <Component {...pageProps} />
+      <AuthProvider>
+        <Component {...pageProps} />
+      </AuthProvider>
     </ThemeProvider>
   );
 }

--- a/packages/frontend/src/pages/callback.tsx
+++ b/packages/frontend/src/pages/callback.tsx
@@ -1,0 +1,31 @@
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import { useAuth } from '../lib/AuthProvider';
+
+export default function CallbackPage() {
+  const router = useRouter();
+  const { login } = useAuth();
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!router.isReady) return;
+    const query = window.location.search;
+    fetch(`http://localhost:8000/auth/callback${query}`)
+      .then(r => r.ok ? r.json() : Promise.reject(r.statusText))
+      .then(data => {
+        if (data.id_token) {
+          login(data.id_token, data.eligibility);
+          router.replace('/dashboard');
+        } else {
+          setError('No token received');
+        }
+      })
+      .catch(() => setError('Login failed'));
+  }, [router.isReady]);
+
+  return (
+    <div style={{display:'flex',justifyContent:'center',paddingTop:'2rem'}}>
+      {error ? <p style={{color:'red'}}>{error}</p> : <p>Processing login...</p>}
+    </div>
+  );
+}

--- a/packages/frontend/src/pages/dashboard.tsx
+++ b/packages/frontend/src/pages/dashboard.tsx
@@ -1,0 +1,60 @@
+import useSWR from 'swr';
+import { useAuth } from '../lib/AuthProvider';
+import withAuth from '../components/withAuth';
+import NavBar from '../components/NavBar';
+
+interface Election {
+  id: number;
+  meta: string;
+  start: number;
+  end: number;
+  status: string;
+  tally?: string;
+}
+
+const fetcher = ([url, token]: [string, string]) => fetch(`http://localhost:8000${url}`, {
+  headers: { Authorization: `Bearer ${token}` }
+}).then(r => {
+  if (!r.ok) throw new Error(r.statusText);
+  return r.json();
+});
+
+function DashboardPage() {
+  const { token, logout, eligibility } = useAuth();
+  const { data, error } = useSWR<Election[]>(token ? ['/elections', token] as [string, string] : null, fetcher);
+
+  if (error) {
+    if (error.message === 'Unauthorized') logout();
+    return <p style={{color:'red'}}>Failed to load elections</p>;
+  }
+
+  return (
+    <>
+      <NavBar />
+      <div style={{padding:'1rem'}}>
+        {eligibility && <a href="/elections/create">Create Election</a>}
+        <h2>Election List</h2>
+        {!data ? <p>Loading...</p> : (
+          <table>
+            <thead>
+              <tr><th>ID</th><th>Meta</th><th>Start</th><th>End</th><th>Status</th></tr>
+            </thead>
+            <tbody>
+              {data.map(e => (
+                <tr key={e.id}>
+                  <td><a href={`/elections/${e.id}`}>{e.id}</a></td>
+                  <td>{e.meta}</td>
+                  <td>{e.start}</td>
+                  <td>{e.end}</td>
+                  <td>{e.status}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </>
+  );
+}
+
+export default withAuth(DashboardPage);

--- a/packages/frontend/src/pages/elections/[id].tsx
+++ b/packages/frontend/src/pages/elections/[id].tsx
@@ -1,0 +1,59 @@
+import { useRouter } from 'next/router';
+import useSWR from 'swr';
+import NavBar from '../../components/NavBar';
+import withAuth from '../../components/withAuth';
+import { useAuth } from '../../lib/AuthProvider';
+
+interface Election {
+  id: number;
+  meta: string;
+  start: number;
+  end: number;
+  status: string;
+  tally?: string;
+}
+
+const fetcher = ([url, token]: [string, string]) => fetch(`http://localhost:8000${url}`, {
+  headers: { Authorization: `Bearer ${token}` }
+}).then(r => {
+  if (!r.ok) throw new Error(r.statusText);
+  return r.json();
+});
+
+function ElectionDetail() {
+  const router = useRouter();
+  const { token, eligibility, logout } = useAuth();
+  const id = router.query.id;
+  const { data, error } = useSWR<Election>(id && token ? [`/elections/${id}`, token] as [string, string] : null, fetcher);
+
+  if (error) {
+    if (error.message === 'Unauthorized') logout();
+    return <p style={{color:'red'}}>Error loading</p>;
+  }
+
+  return (
+    <>
+      <NavBar />
+      <div style={{padding:'1rem'}}>
+        {!data ? <p>Loading...</p> : (
+          <div>
+            <h2>Election {data.id}</h2>
+            <p>Meta: {data.meta}</p>
+            <p>Start: {data.start}</p>
+            <p>End: {data.end}</p>
+            <p>Status: {data.status}</p>
+            {data.tally && <p>Tally: {data.tally}</p>}
+            {data.status === 'open' && eligibility && (
+              <a href={`/vote?id=${data.id}`}>Vote</a>
+            )}
+            {data.status !== 'open' && eligibility && (
+              <button onClick={() => alert('run tally placeholder')}>Run Tally</button>
+            )}
+          </div>
+        )}
+      </div>
+    </>
+  );
+}
+
+export default withAuth(ElectionDetail);

--- a/packages/frontend/src/pages/elections/create.tsx
+++ b/packages/frontend/src/pages/elections/create.tsx
@@ -1,0 +1,45 @@
+import { useState } from 'react';
+import { keccak256, toUtf8Bytes } from 'ethers/lib/utils';
+import { useAuth } from '../../lib/AuthProvider';
+import withAuth from '../../components/withAuth';
+import NavBar from '../../components/NavBar';
+
+function CreateElectionPage() {
+  const { token, eligibility } = useAuth();
+  const [meta, setMeta] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = async () => {
+    if (!eligibility) return;
+    const hash = keccak256(toUtf8Bytes(meta));
+    const res = await fetch('http://localhost:8000/elections', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ meta_hash: hash }),
+    });
+    if (res.ok) {
+      window.location.href = '/dashboard';
+    } else {
+      setError('Failed to create');
+    }
+  };
+
+  if (!eligibility) return <p>Not authorized</p>;
+
+  return (
+    <>
+      <NavBar />
+      <div style={{padding:'1rem'}}>
+        <h2>Create Election</h2>
+        <input value={meta} onChange={e => setMeta(e.target.value)} placeholder="metadata" />
+        <button onClick={submit}>Submit</button>
+        {error && <p style={{color:'red'}}>{error}</p>}
+      </div>
+    </>
+  );
+}
+
+export default withAuth(CreateElectionPage);

--- a/packages/frontend/src/pages/index.jsx
+++ b/packages/frontend/src/pages/index.jsx
@@ -1,13 +1,16 @@
 import ThemeToggle from '../components/ThemeToggle';
 import GasFeeEstimator from '../components/GasFeeEstimator';
+import NavBar from '../components/NavBar';
 
 export default function Home() {
   return (
-    <main style={{ display:'flex',alignItems:'center',justifyContent:'center',height:'100vh', gap:'1rem' }}>
-      <ThemeToggle />
-      <a href="http://localhost:8000/auth/initiate">Log in with eID</a>
-      <a href="/solana">View Solana Chart</a>
-      <div>Gas: <GasFeeEstimator /></div>
-    </main>
+    <>
+      <NavBar />
+      <main style={{ display:'flex',alignItems:'center',justifyContent:'center',height:'80vh', gap:'1rem' }}>
+        <ThemeToggle />
+        <a href="/solana">View Solana Chart</a>
+        <div>Gas: <GasFeeEstimator /></div>
+      </main>
+    </>
   )
 }

--- a/packages/frontend/src/pages/vote.tsx
+++ b/packages/frontend/src/pages/vote.tsx
@@ -1,23 +1,48 @@
 import { useState } from "react";
 import { ethers } from "ethers";
+import { useRouter } from "next/router";
 import { bundleSubmitVote } from "../lib/accountAbstraction";
+import withAuth from "../components/withAuth";
+import NavBar from "../components/NavBar";
+import { useAuth } from "../lib/AuthProvider";
 
-export default function VotePage() {
+function VotePage() {
+    const router = useRouter();
+    const { token, logout } = useAuth();
     const [receipt, setReceipt] = useState<string>();
+    const id = router.query.id as string | undefined;
+
     const cast = async (option: 0 | 1) => {
         const provider = new ethers.providers.Web3Provider((window as any).ethereum);
         await provider.send("eth_requestAccounts", []);
         const signer = provider.getSigner();
-        // fetch your MACI voice‑credit proof
-        const { nonce, vcProof } = await fetch("/api/maci/getProof").then(r => r.json());
-        const userOpHash = await bundleSubmitVote(signer, option, nonce, vcProof);
-        setReceipt(userOpHash);
+        const proofRes = await fetch(`http://localhost:8000/api/maci/getProof`, {
+            headers: { Authorization: `Bearer ${token}` }
+        });
+        if (!proofRes.ok) {
+            logout();
+            return;
+        }
+        const { nonce, vcProof } = await proofRes.json();
+        try {
+            const userOpHash = await bundleSubmitVote(signer, option, nonce, vcProof);
+            setReceipt(userOpHash);
+        } catch (e:any) {
+            setReceipt("error: " + e.message);
+        }
     };
+
     return (
-        <div>
-            <button onClick={() => cast(0)}>Vote A</button>
-            <button onClick={() => cast(1)}>Vote B</button>
-            {receipt && <p>Your vote receipt: {receipt}</p>}
-        </div>
+        <>
+            <NavBar />
+            <div style={{padding:'1rem'}}>
+                <h2>Vote on election {id}</h2>
+                <button onClick={() => cast(0)}>Vote A</button>
+                <button onClick={() => cast(1)}>Vote B</button>
+                {receipt && <p>Your vote receipt: {receipt}</p>}
+            </div>
+        </>
     );
 }
+
+export default withAuth(VotePage);


### PR DESCRIPTION
## Summary
- implement AuthProvider with localStorage persistence
- add login callback handler and protected route HOC
- create navigation bar with login/logout actions
- fetch elections on dashboard and add election details pages
- integrate token in vote flow

## Testing
- `yarn --cwd packages/frontend type-check`


------
https://chatgpt.com/codex/tasks/task_e_6840990d6d1483278642c3b47ef4f123