### PR TITLE
Connect backend POST /elections to ElectionManager

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -2,6 +2,6 @@ FROM python:3.11-slim
 WORKDIR /app
 COPY packages/backend /app/packages/backend
 # pin uvicorn to avoid old apt versions that miss the Server class
-RUN pip install fastapi "uvicorn>=0.27" python-jose[cryptography] httpx sqlalchemy
+RUN pip install fastapi "uvicorn>=0.27" python-jose[cryptography] httpx sqlalchemy web3 eth-account
 EXPOSE 8000
 CMD ["python", "-m", "uvicorn", "packages.backend.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/packages/backend/requirements.txt
+++ b/packages/backend/requirements.txt
@@ -2,5 +2,7 @@ fastapi
 uvicorn
 sqlalchemy
 python-jose[cryptography]
-httpx
+httpx<0.25
+web3
+eth-account
 pytest

--- a/packages/backend/schemas.py
+++ b/packages/backend/schemas.py
@@ -17,8 +17,6 @@ class ElectionSchema(BaseModel):
 
 class CreateElectionSchema(BaseModel):
     meta_hash: str
-    start: int
-    end: int
 
     @validator("meta_hash")
     def validate_meta(cls, v):
@@ -26,12 +24,6 @@ class CreateElectionSchema(BaseModel):
             raise ValueError("meta_hash must be 0x-prefixed 32-byte hex string")
         return v
 
-    @validator("end")
-    def check_end(cls, v, values):
-        start = values.get("start")
-        if start is not None and v <= start:
-            raise ValueError("end must be greater than start")
-        return v
 
 
 class UpdateElectionSchema(BaseModel):


### PR DESCRIPTION
## Summary
- call the ElectionManager contract when creating an election
- record chain start/end blocks in DB
- add Web3 dependencies and update Dockerfile
- adjust API schema and unit tests

## Testing
- `pip install -r packages/backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840af366d048327aae427724b06353d