### PR TITLE
Implement build manifest generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ packages/frontend/.next
 # Yarn Plug'n'Play artefacts
 .pnp.cjs
 .pnp.loader.mjs
+artifacts/
+!artifacts/
+!artifacts/manifest.json

--- a/artifacts/manifest.json
+++ b/artifacts/manifest.json
@@ -1,0 +1,7 @@
+{
+  "0079db54cbac930828c998c637bb910c7a963a60bda797c0fbfd0b9c5d66f6f9": {
+    "r1cs": "artifacts/batch_tally/0079db54cbac930828c998c637bb910c7a963a60bda797c0fbfd0b9c5d66f6f9/batch_tally.r1cs",
+    "wasm": "artifacts/batch_tally/0079db54cbac930828c998c637bb910c7a963a60bda797c0fbfd0b9c5d66f6f9/batch_tally.wasm",
+    "zkey": "artifacts/batch_tally/0079db54cbac930828c998c637bb910c7a963a60bda797c0fbfd0b9c5d66f6f9/batch_tally.zkey"
+  }
+}

--- a/scripts/build_manifest.py
+++ b/scripts/build_manifest.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+import hashlib, json, os, subprocess, glob
+
+ARTIFACTS_DIR = "artifacts"
+PTAU_FILE = os.environ.get("PTAU_FILE", "pot12_final.ptau")
+
+manifest = {}
+
+for cfile in glob.glob("circuits/**/*.circom", recursive=True):
+    with open(cfile, "rb") as f:
+        h = hashlib.sha256(f.read()).hexdigest()
+    name = os.path.splitext(os.path.basename(cfile))[0]
+    out_dir = os.path.join(ARTIFACTS_DIR, name, h)
+    os.makedirs(out_dir, exist_ok=True)
+    r1cs = os.path.join(out_dir, f"{name}.r1cs")
+    wasm = os.path.join(out_dir, f"{name}.wasm")
+    zkey = os.path.join(out_dir, f"{name}.zkey")
+    if not os.path.exists(r1cs) or not os.path.exists(wasm):
+        try:
+            subprocess.run(
+                [
+                    "npx",
+                    "-y",
+                    "circom2",
+                    cfile,
+                    "--r1cs",
+                    "--wasm",
+                    "--sym",
+                    "-o",
+                    out_dir,
+                ],
+                check=True,
+            )
+        except subprocess.CalledProcessError:
+            print(f"skip {cfile}: circom compilation failed")
+            continue
+    if os.path.exists(PTAU_FILE) and not os.path.exists(zkey):
+        try:
+            subprocess.run(
+                [
+                    "npx",
+                    "-y",
+                    "snarkjs",
+                    "groth16",
+                    "setup",
+                    r1cs,
+                    PTAU_FILE,
+                    zkey,
+                ],
+                check=True,
+            )
+        except subprocess.CalledProcessError:
+            print(f"skip {cfile}: snarkjs setup failed")
+            continue
+    manifest[h] = {"r1cs": r1cs, "wasm": wasm, "zkey": zkey}
+
+os.makedirs(ARTIFACTS_DIR, exist_ok=True)
+manifest_file = os.path.join(ARTIFACTS_DIR, "manifest.json")
+with open(manifest_file, "w") as f:
+    json.dump(manifest, f, indent=2)
+print("Wrote", manifest_file)


### PR DESCRIPTION
## Summary
- add script to compile circuits and generate an artifact manifest
- store example `artifacts/manifest.json`
- ignore build artifacts but keep manifest

## Testing
- `pytest -q`
- `python3 scripts/build_manifest.py`

------
https://chatgpt.com/codex/tasks/task_e_68411f227e308327a48d1e33d2053f5b