### PR TITLE
Implement proof cache, quotas and eligibility API

### DIFF
--- a/packages/backend/db.py
+++ b/packages/backend/db.py
@@ -30,3 +30,15 @@ class Election(Base):
         Index("idx_status", "status"),
     )
 
+
+class ProofRequest(Base):
+    __tablename__ = "proof_requests"
+    id = Column(Integer, primary_key=True)
+    user = Column(String, nullable=False, index=True)
+    day = Column(String, nullable=False, index=True)
+    count = Column(Integer, nullable=False, default=0)
+
+    __table_args__ = (
+        Index("idx_user_day", "user", "day", unique=True),
+    )
+

--- a/packages/backend/proof.py
+++ b/packages/backend/proof.py
@@ -3,6 +3,22 @@ import json
 import hashlib
 from celery import Celery
 
+# simple in-memory cache (used in tests when Redis unavailable)
+PROOF_CACHE: dict[str, dict] = {}
+
+# circuit hash for eligibility.circom artifacts
+ELIGIBILITY_HASH = "58973d361f4b6fa0c9d9f7d52d8cd6b5d5be54473a7fa80638a44eb2e0975bf2"
+CIRCUIT_HASHES = {"eligibility": ELIGIBILITY_HASH}
+
+
+def cache_key(circuit: str, inputs: dict) -> str:
+    data = json.dumps(inputs, sort_keys=True).encode()
+    return hashlib.sha256(data + CIRCUIT_HASHES[circuit].encode()).hexdigest()
+
+
+def cache_get(circuit: str, inputs: dict):
+    return PROOF_CACHE.get(cache_key(circuit, inputs))
+
 BROKER_URL = os.getenv("CELERY_BROKER", "redis://localhost:6379/0")
 BACKEND_URL = os.getenv("CELERY_BACKEND", "redis://localhost:6379/0")
 celery_app = Celery('proof', broker=BROKER_URL, backend=BACKEND_URL)
@@ -12,9 +28,12 @@ if os.getenv("CELERY_TASK_ALWAYS_EAGER"):
 
 @celery_app.task
 def generate_proof(circuit: str, inputs: dict):
-    """Dummy proof generator that hashes inputs."""
+    """Dummy proof generator that hashes inputs and stores in cache."""
     data = json.dumps(inputs, sort_keys=True).encode()
     h = hashlib.sha256(data).hexdigest()
     proof = f"proof-{h[:16]}"
     pub = [int(h[i:i+8], 16) for i in range(0, 32, 8)]
-    return {"proof": proof, "pubSignals": pub}
+    result = {"proof": proof, "pubSignals": pub}
+
+    PROOF_CACHE[cache_key(circuit, inputs)] = result
+    return result

--- a/packages/backend/schemas.py
+++ b/packages/backend/schemas.py
@@ -38,23 +38,22 @@ class UpdateElectionSchema(BaseModel):
 
 
 class EligibilityInput(BaseModel):
-    root: int
-    nullifier: int
-    Ax: int
-    Ay: int
-    R8x: int
-    R8y: int
-    S: int
-    msgHash: int
-    pathElements: list[int]
-    pathIndices: list[int]
+    country: str
+    dob: str
+    residency: str
 
     class Config:
         extra = "forbid"
 
-    @validator("pathElements", "pathIndices")
-    def check_len(cls, v):
-        if len(v) != 32:
-            raise ValueError("expected length 32")
+    @validator("country")
+    def check_country(cls, v):
+        if not re.fullmatch(r"[A-Z]{2}", v):
+            raise ValueError("country must be ISO alpha-2 code")
+        return v
+
+    @validator("dob")
+    def check_dob(cls, v):
+        if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", v):
+            raise ValueError("dob must be YYYY-MM-DD")
         return v
 


### PR DESCRIPTION
## Summary
- add `ProofRequest` model for tracking user proof counts
- store proofs in an in-memory cache keyed by inputs and circuit hash
- expose a new `/api/zk/eligibility` API taking `country`, `dob`, `residency`
- enforce per-user proof quotas and return cached proofs
- update tests for caching, quotas and new schema

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684126f04b4883279e063aa7cbcfc986