### PR TITLE
Implement election admin features and eligibility UI

### DIFF
--- a/packages/frontend/__tests__/callback.test.js
+++ b/packages/frontend/__tests__/callback.test.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import { render, waitFor } from '@testing-library/react'
 import router from 'next-router-mock'
 import CallbackPage from '../src/pages/callback'

--- a/packages/frontend/babel.config.js
+++ b/packages/frontend/babel.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  presets: [
+    ['@babel/preset-env', { targets: { node: 'current' } }],
+    '@babel/preset-react',
+    '@babel/preset-typescript'
+  ]
+};

--- a/packages/frontend/jest.config.js
+++ b/packages/frontend/jest.config.js
@@ -1,9 +1,7 @@
 module.exports = {
-  preset: 'ts-jest',
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
-    '^.+\\.jsx?$': 'babel-jest',
+    '^.+\\.(t|j)sx?$': 'babel-jest',
   },
 };

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -32,7 +32,8 @@
     "jest-environment-jsdom": "^29.7.0",
     "babel-jest": "^29.7.0",
     "@babel/preset-env": "^7.24.5",
-    "@babel/preset-react": "^7.24.5"
+    "@babel/preset-react": "^7.24.5",
+    "@babel/preset-typescript": "^7.27.1"
   },
   "packageManager": "yarn@1.22.22"
 }

--- a/packages/frontend/src/components/NavBar.tsx
+++ b/packages/frontend/src/components/NavBar.tsx
@@ -6,7 +6,12 @@ export default function NavBar() {
   return (
     <nav style={{display:'flex',gap:'1rem',padding:'1rem'}}>
       <Link href="/">Home</Link>
-      {isLoggedIn && <Link href="/dashboard">Dashboard</Link>}
+      {isLoggedIn && (
+        <>
+          <Link href="/dashboard">Dashboard</Link>
+          <Link href="/eligibility">Eligibility</Link>
+        </>
+      )}
       {isLoggedIn ? (
         <button onClick={logout}>Logout</button>
       ) : (

--- a/packages/frontend/src/lib/AuthProvider.tsx
+++ b/packages/frontend/src/lib/AuthProvider.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
 
 interface AuthContextValue {
   token: string | null;

--- a/packages/frontend/src/pages/callback.tsx
+++ b/packages/frontend/src/pages/callback.tsx
@@ -1,5 +1,5 @@
+import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
 import { useAuth } from '../lib/AuthProvider';
 
 export default function CallbackPage() {

--- a/packages/frontend/src/pages/elections/[id].tsx
+++ b/packages/frontend/src/pages/elections/[id].tsx
@@ -1,5 +1,6 @@
 import { useRouter } from 'next/router';
 import useSWR from 'swr';
+import { useState } from 'react';
 import NavBar from '../../components/NavBar';
 import withAuth from '../../components/withAuth';
 import { useAuth } from '../../lib/AuthProvider';
@@ -24,7 +25,26 @@ function ElectionDetail() {
   const router = useRouter();
   const { token, eligibility, logout } = useAuth();
   const id = router.query.id;
-  const { data, error } = useSWR<Election>(id && token ? [`/elections/${id}`, token] as [string, string] : null, fetcher);
+  const { data, error, mutate } = useSWR<Election>(id && token ? [`/elections/${id}`, token] as [string, string] : null, fetcher);
+  const [newStatus, setNewStatus] = useState('');
+  const [newTally, setNewTally] = useState('');
+
+  const submitUpdate = async () => {
+    const payload: any = {};
+    if (newStatus) payload.status = newStatus;
+    if (newTally) payload.tally = newTally;
+    await fetch(`http://localhost:8000/elections/${id}`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(payload),
+    });
+    setNewStatus('');
+    setNewTally('');
+    mutate();
+  };
 
   if (error) {
     if (error.message === 'Unauthorized') logout();
@@ -48,6 +68,28 @@ function ElectionDetail() {
             )}
             {data.status !== 'open' && eligibility && (
               <button onClick={() => alert('run tally placeholder')}>Run Tally</button>
+            )}
+            {eligibility && (
+              <div style={{marginTop:'1rem'}}>
+                <h3>Update Election</h3>
+                <div>
+                  <label>Status:
+                    <select value={newStatus} onChange={e => setNewStatus(e.target.value)}>
+                      <option value=''>--</option>
+                      <option value='pending'>pending</option>
+                      <option value='open'>open</option>
+                      <option value='closed'>closed</option>
+                      <option value='tallied'>tallied</option>
+                    </select>
+                  </label>
+                </div>
+                <div>
+                  <label>Tally:
+                    <input value={newTally} onChange={e => setNewTally(e.target.value)} />
+                  </label>
+                </div>
+                <button onClick={submitUpdate}>Submit</button>
+              </div>
             )}
           </div>
         )}

--- a/packages/frontend/src/pages/eligibility.tsx
+++ b/packages/frontend/src/pages/eligibility.tsx
@@ -1,0 +1,73 @@
+import React, { useState } from 'react';
+import withAuth from '../components/withAuth';
+import NavBar from '../components/NavBar';
+import { useAuth } from '../lib/AuthProvider';
+
+function EligibilityPage() {
+  const { token } = useAuth();
+  const [country, setCountry] = useState('');
+  const [dob, setDob] = useState('');
+  const [residency, setResidency] = useState('');
+  const [proof, setProof] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const submit = async () => {
+    setLoading(true);
+    setError(null);
+    setProof(null);
+    const payload = { country, dob, residency };
+    const res = await fetch('http://localhost:8000/api/zk/eligibility', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(payload),
+    });
+    if (res.status === 429) {
+      setError('quota exceeded');
+      setLoading(false);
+      return;
+    }
+    const data = await res.json();
+    const jobId = data.job_id;
+    let result = data;
+    if (!data.status) {
+      // initial response is job id
+      while (true) {
+        const poll = await fetch(`http://localhost:8000/api/zk/eligibility/${jobId}`).then(r => r.json());
+        if (poll.status === 'done') { result = poll; break; }
+        if (poll.status === 'error') { setError('proof error'); setLoading(false); return; }
+        await new Promise(r => setTimeout(r, 1000));
+      }
+    }
+    if (result.proof) setProof(result.proof);
+    else setError('proof error');
+    setLoading(false);
+  };
+
+  return (
+    <>
+      <NavBar />
+      <div style={{padding:'1rem'}}>
+        <h2>Eligibility Proof</h2>
+        <div>
+          <label>Country: <input value={country} onChange={e => setCountry(e.target.value)} /></label>
+        </div>
+        <div>
+          <label>DOB: <input type="date" value={dob} onChange={e => setDob(e.target.value)} /></label>
+        </div>
+        <div>
+          <label>Residency: <input value={residency} onChange={e => setResidency(e.target.value)} /></label>
+        </div>
+        <button onClick={submit} disabled={loading}>Submit</button>
+        {loading && <p>Waiting for proof...</p>}
+        {proof && <p>Proof: {proof}</p>}
+        {error && <p style={{color:'red'}}>{error}</p>}
+      </div>
+    </>
+  );
+}
+
+export default withAuth(EligibilityPage);


### PR DESCRIPTION
## Summary
- handle OAuth callback via React components and store eligibility
- add link to eligibility proof page in NavBar
- support editing elections from the election detail page
- implement eligibility proof submission UI
- configure frontend Jest with Babel

## Testing
- `npx tsc -p services/relay-daemon`
- `pytest -q`
- `cd packages/frontend && npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_684133b9e3048327be58b68fc9daf2e7