### PR TITLE
Fix Celery missing in backend image

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -1,14 +1,13 @@
- FROM python:3.11-slim
- WORKDIR /app
+FROM python:3.11-slim
+WORKDIR /app
 
-# Copy backend code and requirements
+# Install dependencies first for better build caching
+COPY packages/backend/requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy backend source and circuit manifest
 COPY packages/backend /app/packages/backend
-COPY packages/backend/requirements.txt /app/requirements.txt
-# copy circuit manifest
 COPY artifacts/manifest.json /app/circuits/manifest.json
-
-# Install everything from requirements.txt (including celery, redis, grpcio, etc.)
-RUN pip install --no-cache-dir -r /app/requirements.txt
 
 EXPOSE 8000
 CMD ["python", "-m", "uvicorn", "packages.backend.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- install backend requirements before copying code

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68413d3711508327a13944a9798b01c8