### PR TITLE
Fix container startup errors

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -3,7 +3,8 @@ WORKDIR /app
 
 # Install dependencies first for better build caching
 COPY packages/backend/requirements.txt ./requirements.txt
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt && \
+    pip install --no-cache-dir celery
 
 # Copy backend source and circuit manifest
 COPY packages/backend /app/packages/backend

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "license": "MIT",
   "scripts": {
     "build": "tsc",
-    "test": "yarn exec tsc -p services/relay-daemon"
+    "test": "npx tsc -p services/relay-daemon"
   },
   "packageManager": "yarn@1.22.22"
 }

--- a/services/orchestrator/main.py
+++ b/services/orchestrator/main.py
@@ -3,7 +3,6 @@ import os
 import time
 import subprocess
 from web3 import Web3
-    
 from web3.exceptions import LogTopicError
 
 EVM_RPC      = os.getenv("EVM_RPC", "http://127.0.0.1:8545")
@@ -44,6 +43,17 @@ ELECTION_MANAGER_ABI = [
       "name":"tallyVotes","outputs":[],"stateMutability":"nonpayable","type":"function"
     }
 ]
+
+
+def connect_w3() -> Web3:
+    """Try to connect to the EVM provider until it is reachable."""
+    for _ in range(20):
+        w3 = Web3(Web3.HTTPProvider(EVM_RPC))
+        if w3.is_connected():
+            return w3
+        print("⏳ waiting for anvil…")
+        time.sleep(3)
+    raise RuntimeError("EVM RPC not reachable")
 
 
 
@@ -115,7 +125,7 @@ def submit_tally(w3, mgr, acct, calldata):
     print("✅ Tally on-chain!")
 
 def main():
-    w3 = Web3(Web3.HTTPProvider(EVM_RPC))
+    w3 = connect_w3()
     mgr = w3.eth.contract(address=FACTORY_ADDR, abi=ELECTION_MANAGER_ABI)
     acct = w3.eth.account.from_key(PRIVATE_KEY)
 

--- a/services/relay-daemon/tsconfig.json
+++ b/services/relay-daemon/tsconfig.json
@@ -6,6 +6,7 @@
     "esModuleInterop": true,
     "strict": true,
     "outDir": "dist",
+    "rootDir": ".",
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "types": ["node"]


### PR DESCRIPTION
## Summary
- compile relay daemon to expected output location
- wait for the anvil RPC before orchestrator starts
- install celery in backend image and adjust TypeScript test command

## Testing
- `yarn test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68413ffc3d508327ad80a1ed4485d7c1