### PR TITLE
Implement popup login flow

### DIFF
--- a/docs/frontend_pbis.md
+++ b/docs/frontend_pbis.md
@@ -56,3 +56,18 @@ The following product backlog items (PBIs) capture upcoming frontend work.
 
 ## F-17 EIP-6963 Wallet Standard
 - Replace wagmi auto-detect with official API; Storybook example.
+## F-18 Frontend Login Page & Redirect to OAuth Initiation
+- Implement a dedicated `/login` route with a “Log in with eID” button.
+- Fetch `/auth/initiate` and open the returned URL or HTML inside a popup window so the main tab never shows raw JSON.
+
+## F-19 Callback Handling & Token Storage in AuthProvider
+- Popup posts `{ id_token, eligibility }` back to the opener after `/auth/callback`.
+- `AuthProvider` listens for the message, stores the token and eligibility, then redirects to `/dashboard`.
+
+## F-20 Dashboard & Navbar Adjustments Post-Login
+- Navbar shows “Logout” when authenticated and guards protected pages.
+- Logged-in users visiting `/login` are redirected to `/dashboard` automatically.
+
+## F-21 Eligibility & Voting Links Only Visible When Eligible
+- Navbar and dashboard links depend on the `eligibility` flag from the backend.
+- Voting buttons disabled when `eligibility === false`.

--- a/packages/frontend/__tests__/authprovider.message.test.js
+++ b/packages/frontend/__tests__/authprovider.message.test.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { render, waitFor, act } from '@testing-library/react';
+import router from 'next-router-mock';
+import { AuthProvider } from '../src/lib/AuthProvider';
+import { useAuth } from '../src/lib/AuthProvider';
+
+jest.mock('next/router', () => require('next-router-mock'));
+
+function Dummy() {
+  const { isLoggedIn, eligibility } = useAuth();
+  return <span>{isLoggedIn ? `logged-${eligibility}` : 'anon'}</span>;
+}
+
+describe('postMessage login', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    router.setCurrentUrl('/');
+  });
+
+  it('updates auth state and redirects', async () => {
+    render(
+      <AuthProvider>
+        <Dummy />
+      </AuthProvider>
+    );
+    const evt = new MessageEvent('message', {
+      origin: 'http://localhost:3000',
+      data: { id_token: 'jwt', eligibility: true }
+    });
+    await act(async () => {
+      window.dispatchEvent(evt);
+    });
+    await waitFor(() => expect(localStorage.getItem('id_token')).toBe('jwt'));
+    expect(router.asPath).toBe('/dashboard');
+  });
+});

--- a/packages/frontend/__tests__/callback.test.js
+++ b/packages/frontend/__tests__/callback.test.js
@@ -1,29 +1,21 @@
 import React from 'react';
-import { render, waitFor } from '@testing-library/react'
-import router from 'next-router-mock'
-import CallbackPage from '../src/pages/callback'
-import { AuthProvider } from '../src/lib/AuthProvider'
+import { render, waitFor } from '@testing-library/react';
+import router from 'next-router-mock';
+import CallbackPage from '../src/pages/callback';
 
-jest.mock('next/router', () => require('next-router-mock'))
+jest.mock('next/router', () => require('next-router-mock'));
 
-describe('login flow', () => {
+describe('callback page', () => {
   beforeEach(() => {
-    localStorage.clear()
     globalThis.fetch = jest.fn().mockResolvedValue({
       ok: true,
       json: async () => ({ id_token: 'jwt', eligibility: true })
-    })
-  })
+    });
+    router.setCurrentUrl('/callback?code=dummy');
+  });
 
-  it('stores token and redirects', async () => {
-    router.setCurrentUrl('/callback?code=dummy')
-    render(
-      <AuthProvider>
-        <CallbackPage />
-      </AuthProvider>
-    )
-    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalled())
-    expect(localStorage.getItem('id_token')).toBe('jwt')
-    expect(router.asPath).toBe('/dashboard')
-  })
-})
+  it('redirects to login without opener', async () => {
+    render(<CallbackPage />);
+    await waitFor(() => expect(router.asPath).toBe('/login'));
+  });
+});

--- a/packages/frontend/src/components/NavBar.tsx
+++ b/packages/frontend/src/components/NavBar.tsx
@@ -15,7 +15,7 @@ export default function NavBar() {
       {isLoggedIn ? (
         <button onClick={logout}>Logout</button>
       ) : (
-        <a href="http://localhost:8000/auth/initiate">Log in with eID</a>
+        <Link href="/login">Log in with eID</Link>
       )}
     </nav>
   );

--- a/packages/frontend/src/pages/login.tsx
+++ b/packages/frontend/src/pages/login.tsx
@@ -1,0 +1,38 @@
+import { useEffect } from 'react';
+import NavBar from '../components/NavBar';
+import { useRouter } from 'next/router';
+import { useAuth } from '../lib/AuthProvider';
+
+export default function LoginPage() {
+  const router = useRouter();
+  const { isLoggedIn } = useAuth();
+
+  useEffect(() => {
+    if (isLoggedIn) router.replace('/dashboard');
+  }, [isLoggedIn, router]);
+
+  const startLogin = async () => {
+    const res = await fetch('http://localhost:8000/auth/initiate', { redirect: 'manual' });
+    const location = res.status >= 300 && res.status < 400 ? res.headers.get('Location') : undefined;
+    if (res.ok && res.headers.get('content-type')?.includes('text/html') && !location) {
+      const html = await res.text();
+      const popup = window.open('', 'login', 'width=500,height=600');
+      if (popup) {
+        popup.document.write(html);
+        popup.document.close();
+      }
+      return;
+    }
+    const url = location || 'http://localhost:8000/auth/initiate';
+    window.open(url, 'login', 'width=500,height=600');
+  };
+
+  return (
+    <>
+      <NavBar />
+      <div style={{display:'flex',justifyContent:'center',padding:'2rem'}}>
+        <button onClick={startLogin}>Log in with eID</button>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- document PBIs for login and dashboard redirect
- create a /login page that invokes backend auth in a popup
- wire popup messages into `AuthProvider`
- handle auth callback inside popup
- update navbar
- add unit tests for new message flow

## Testing
- `yarn install`
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_68414329f9e08327bd772d1aabc704ea