### PR TITLE
Implement F-20 and F-21 login flow features

### DIFF
--- a/packages/frontend/src/components/NavBar.tsx
+++ b/packages/frontend/src/components/NavBar.tsx
@@ -2,14 +2,14 @@ import Link from 'next/link';
 import { useAuth } from '../lib/AuthProvider';
 
 export default function NavBar() {
-  const { isLoggedIn, logout } = useAuth();
+  const { isLoggedIn, eligibility, logout } = useAuth();
   return (
     <nav style={{display:'flex',gap:'1rem',padding:'1rem'}}>
       <Link href="/">Home</Link>
       {isLoggedIn && (
         <>
           <Link href="/dashboard">Dashboard</Link>
-          <Link href="/eligibility">Eligibility</Link>
+          {eligibility && <Link href="/eligibility">Eligibility</Link>}
         </>
       )}
       {isLoggedIn ? (

--- a/packages/frontend/src/components/withAuth.tsx
+++ b/packages/frontend/src/components/withAuth.tsx
@@ -7,8 +7,8 @@ export default function withAuth(Component: React.ComponentType<any>): React.FC<
     const { isLoggedIn } = useAuth();
     const router = useRouter();
     useEffect(() => {
-      if (!isLoggedIn) router.replace('/');
-    }, [isLoggedIn]);
+      if (!isLoggedIn) router.replace('/login');
+    }, [isLoggedIn, router]);
     if (!isLoggedIn) return null;
     return <Component {...props} />;
   };

--- a/packages/frontend/src/pages/vote.tsx
+++ b/packages/frontend/src/pages/vote.tsx
@@ -8,7 +8,7 @@ import { useAuth } from "../lib/AuthProvider";
 
 function VotePage() {
     const router = useRouter();
-    const { token, logout } = useAuth();
+    const { token, eligibility, logout } = useAuth();
     const [receipt, setReceipt] = useState<string>();
     const id = router.query.id as string | undefined;
 
@@ -50,8 +50,9 @@ function VotePage() {
             <NavBar />
             <div style={{padding:'1rem'}}>
                 <h2>Vote on election {id}</h2>
-                <button onClick={() => cast(0)}>Vote A</button>
-                <button onClick={() => cast(1)}>Vote B</button>
+                <button onClick={() => cast(0)} disabled={!eligibility}>Vote A</button>
+                <button onClick={() => cast(1)} disabled={!eligibility}>Vote B</button>
+                {!eligibility && <p style={{color:'red'}}>Not eligible to vote</p>}
                 {receipt && <p>Your vote receipt: {receipt}</p>}
             </div>
         </>


### PR DESCRIPTION
## Summary
- adjust navbar links based on login/eligibility
- redirect unauthenticated users to `/login`
- disable vote buttons for ineligible users

## Testing
- `yarn test` (backend TypeScript compile)
- `cd packages/frontend && yarn test`


------
https://chatgpt.com/codex/tasks/task_e_6841450f458c8327809d7a7b223a766b