### PR TITLE
Fix orchestrator RPC retries

### DIFF
--- a/docs/handbook/README.md
+++ b/docs/handbook/README.md
@@ -11,6 +11,11 @@ proof orchestrator and relay):
 docker-compose up -d
 ```
 
+The orchestrator service connects to an EVM JSON‑RPC endpoint. When using
+`docker-compose` an instance of **anvil** starts automatically and the
+orchestrator will retry connecting for up to 20 attempts. Set `EVM_RPC` to a
+custom URL or use `EVM_MAX_RETRIES=0` to wait indefinitely.
+
 The frontend will be available on `http://localhost:3000`, the API on
 `http://localhost:8000` and Postgres on `localhost:5432`.
 


### PR DESCRIPTION
## Summary
- make EVM RPC retry count configurable with `EVM_MAX_RETRIES`
- document orchestrator startup expectations

## Testing
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684147f94be4832794f010650a1243f4