### PR TITLE
Implement initial UX items

### DIFF
--- a/packages/frontend/__tests__/authprovider.message.test.js
+++ b/packages/frontend/__tests__/authprovider.message.test.js
@@ -31,6 +31,7 @@ describe('postMessage login', () => {
       window.dispatchEvent(evt);
     });
     await waitFor(() => expect(localStorage.getItem('id_token')).toBe('jwt'));
+    expect(localStorage.getItem('auth_mode')).toBe('eid');
     expect(router.asPath).toBe('/dashboard');
   });
 });

--- a/packages/frontend/src/components/AuthChip.tsx
+++ b/packages/frontend/src/components/AuthChip.tsx
@@ -1,0 +1,11 @@
+import { useAuth } from '../lib/AuthProvider';
+
+export default function AuthChip() {
+  const { mode } = useAuth();
+  const color = mode === 'eid' ? 'green' : mode === 'mock' ? 'blue' : 'gray';
+  return (
+    <span style={{marginLeft:'auto',padding:'0 0.5rem',borderRadius:'9999px',background:color,color:'white'}}>
+      {mode}
+    </span>
+  );
+}

--- a/packages/frontend/src/components/MockLoginModal.tsx
+++ b/packages/frontend/src/components/MockLoginModal.tsx
@@ -1,0 +1,32 @@
+import { useState } from 'react';
+import { useAuth } from '../lib/AuthProvider';
+
+export default function MockLoginModal({ onClose }: { onClose: () => void }) {
+  const { login } = useAuth();
+  const [email, setEmail] = useState('');
+  const [error, setError] = useState('');
+
+  const submit = async () => {
+    if (!/^[^@]+@[^@]+\.[^@]+$/.test(email)) { setError('invalid email'); return; }
+    const res = await fetch(`http://localhost:8000/auth/callback?user=${encodeURIComponent(email)}`);
+    const data = await res.json();
+    if (data.id_token) {
+      login(data.id_token, data.eligibility, 'mock');
+      onClose();
+    } else {
+      setError('login failed');
+    }
+  };
+
+  return (
+    <div style={{position:'fixed',top:0,left:0,right:0,bottom:0,background:'rgba(0,0,0,0.5)',display:'flex',alignItems:'center',justifyContent:'center'}}>
+      <div style={{background:'white',padding:'1rem',minWidth:'300px'}}>
+        <h3>Mock Login</h3>
+        <input type="email" value={email} onChange={e=>setEmail(e.target.value)} placeholder="Email" />
+        <button onClick={submit}>Login</button>
+        <button onClick={onClose}>Cancel</button>
+        {error && <p style={{color:'red'}}>{error}</p>}
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/components/NavBar.tsx
+++ b/packages/frontend/src/components/NavBar.tsx
@@ -1,10 +1,12 @@
 import Link from 'next/link';
 import { useAuth } from '../lib/AuthProvider';
+import ThemeToggle from './ThemeToggle';
+import AuthChip from './AuthChip';
 
 export default function NavBar() {
   const { isLoggedIn, eligibility, logout } = useAuth();
   return (
-    <nav style={{display:'flex',gap:'1rem',padding:'1rem'}}>
+    <nav style={{display:'flex',gap:'1rem',padding:'1rem',alignItems:'center'}}>
       <Link href="/">Home</Link>
       {isLoggedIn && (
         <>
@@ -17,6 +19,8 @@ export default function NavBar() {
       ) : (
         <Link href="/login">Log in with eID</Link>
       )}
+      <ThemeToggle />
+      <AuthChip />
     </nav>
   );
 }

--- a/packages/frontend/src/lib/ToastProvider.tsx
+++ b/packages/frontend/src/lib/ToastProvider.tsx
@@ -1,0 +1,32 @@
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+
+interface Toast { id: number; type: 'error' | 'success' | 'info'; message: string; }
+
+const ToastContext = createContext<{ showToast: (t: Omit<Toast,'id'>) => void }>({ showToast: () => {} });
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const showToast = ({ type, message }: Omit<Toast, 'id'>) => {
+    const id = Date.now();
+    setToasts(t => [...t, { id, type, message }]);
+    setTimeout(() => setToasts(t => t.filter(to => to.id !== id)), 5000);
+  };
+
+  return (
+    <ToastContext.Provider value={{ showToast }}>
+      {children}
+      <div style={{position:'fixed',bottom:'1rem',right:'1rem',display:'flex',flexDirection:'column',gap:'0.5rem',zIndex:1000}}>
+        {toasts.map(t => (
+          <div key={t.id} style={{padding:'0.5rem 1rem',border:'1px solid',borderRadius:'4px',background:'white',color:t.type==='error'?'red':t.type==='success'?'green':'black'}}>
+            {t.message}
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  return useContext(ToastContext);
+}

--- a/packages/frontend/src/pages/_app.tsx
+++ b/packages/frontend/src/pages/_app.tsx
@@ -2,13 +2,16 @@ import type { AppProps } from 'next/app';
 import { ThemeProvider } from 'next-themes';
 import '../styles/globals.css';
 import { AuthProvider } from '../lib/AuthProvider';
+import { ToastProvider } from '../lib/ToastProvider';
 
 export default function MyApp({ Component, pageProps }: AppProps) {
   return (
     <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-      <AuthProvider>
-        <Component {...pageProps} />
-      </AuthProvider>
+      <ToastProvider>
+        <AuthProvider>
+          <Component {...pageProps} />
+        </AuthProvider>
+      </ToastProvider>
     </ThemeProvider>
   );
 }

--- a/packages/frontend/src/pages/elections/create.tsx
+++ b/packages/frontend/src/pages/elections/create.tsx
@@ -3,11 +3,12 @@ import { keccak256, toUtf8Bytes } from 'ethers/lib/utils';
 import { useAuth } from '../../lib/AuthProvider';
 import withAuth from '../../components/withAuth';
 import NavBar from '../../components/NavBar';
+import { useToast } from '../../lib/ToastProvider';
 
 function CreateElectionPage() {
   const { token, eligibility } = useAuth();
   const [meta, setMeta] = useState('');
-  const [error, setError] = useState<string | null>(null);
+  const { showToast } = useToast();
 
   const submit = async () => {
     if (!eligibility) return;
@@ -23,7 +24,7 @@ function CreateElectionPage() {
     if (res.ok) {
       window.location.href = '/dashboard';
     } else {
-      setError('Failed to create');
+      showToast({ type: 'error', message: 'Failed to create' });
     }
   };
 
@@ -36,7 +37,6 @@ function CreateElectionPage() {
         <h2>Create Election</h2>
         <input value={meta} onChange={e => setMeta(e.target.value)} placeholder="metadata" />
         <button onClick={submit}>Submit</button>
-        {error && <p style={{color:'red'}}>{error}</p>}
       </div>
     </>
   );

--- a/packages/frontend/src/pages/login.tsx
+++ b/packages/frontend/src/pages/login.tsx
@@ -1,17 +1,20 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import NavBar from '../components/NavBar';
 import { useRouter } from 'next/router';
 import { useAuth } from '../lib/AuthProvider';
+import MockLoginModal from '../components/MockLoginModal';
 
 export default function LoginPage() {
   const router = useRouter();
-  const { isLoggedIn } = useAuth();
+  const { isLoggedIn, setMode } = useAuth();
+  const [showMock, setShowMock] = useState(false);
 
   useEffect(() => {
     if (isLoggedIn) router.replace('/dashboard');
   }, [isLoggedIn, router]);
 
   const startLogin = async () => {
+    setMode('eid');
     const res = await fetch('http://localhost:8000/auth/initiate', { redirect: 'manual' });
     const location = res.status >= 300 && res.status < 400 ? res.headers.get('Location') : undefined;
     if (res.ok && res.headers.get('content-type')?.includes('text/html') && !location) {
@@ -27,12 +30,19 @@ export default function LoginPage() {
     window.open(url, 'login', 'width=500,height=600');
   };
 
+  const openMock = () => {
+    setMode('mock');
+    setShowMock(true);
+  };
+
   return (
     <>
       <NavBar />
-      <div style={{display:'flex',justifyContent:'center',padding:'2rem'}}>
+      <div style={{display:'flex',flexDirection:'column',alignItems:'center',gap:'1rem',padding:'2rem'}}>
         <button onClick={startLogin}>Log in with eID</button>
+        <button onClick={openMock}>Mock Login (developer mode)</button>
       </div>
+      {showMock && <MockLoginModal onClose={() => setShowMock(false)} />}
     </>
   );
 }


### PR DESCRIPTION
## Summary
- implement AuthMode context for AuthProvider
- add login modal for mock authentication
- show auth chip in NavBar
- global toast provider and error toast integration
- dual-mode login page
- update tests for auth mode

## Testing
- `npx jest --config packages/frontend/jest.config.js`

------
https://chatgpt.com/codex/tasks/task_e_68414c45a728832799b770ad307cfe81