### PR TITLE
Implement UX-05 skeleton states

### DIFF
--- a/packages/frontend/src/components/Skeleton.tsx
+++ b/packages/frontend/src/components/Skeleton.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+interface SkeletonProps {
+  width?: string | number;
+  height?: string | number;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+export default function Skeleton({ width, height, className = '', style }: SkeletonProps) {
+  return (
+    <div
+      className={`skeleton shimmer ${className}`.trim()}
+      style={{ width, height, ...style }}
+    />
+  );
+}

--- a/packages/frontend/src/pages/dashboard.tsx
+++ b/packages/frontend/src/pages/dashboard.tsx
@@ -2,6 +2,7 @@ import useSWR from 'swr';
 import { useAuth } from '../lib/AuthProvider';
 import withAuth from '../components/withAuth';
 import NavBar from '../components/NavBar';
+import Skeleton from '../components/Skeleton';
 
 interface Election {
   id: number;
@@ -34,7 +35,24 @@ function DashboardPage() {
       <div style={{padding:'1rem'}}>
         {eligibility && <a href="/elections/create">Create Election</a>}
         <h2>Election List</h2>
-        {!data ? <p>Loading...</p> : (
+        {!data ? (
+          <table>
+            <thead>
+              <tr><th>ID</th><th>Meta</th><th>Start</th><th>End</th><th>Status</th></tr>
+            </thead>
+            <tbody>
+              {[1,2,3].map(i => (
+                <tr key={i}>
+                  <td><Skeleton width={20} height={16} /></td>
+                  <td><Skeleton width={80} height={16} /></td>
+                  <td><Skeleton width={80} height={16} /></td>
+                  <td><Skeleton width={80} height={16} /></td>
+                  <td><Skeleton width={60} height={16} /></td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : (
           <table>
             <thead>
               <tr><th>ID</th><th>Meta</th><th>Start</th><th>End</th><th>Status</th></tr>

--- a/packages/frontend/src/pages/elections/[id].tsx
+++ b/packages/frontend/src/pages/elections/[id].tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import NavBar from '../../components/NavBar';
 import withAuth from '../../components/withAuth';
 import { useAuth } from '../../lib/AuthProvider';
+import Skeleton from '../../components/Skeleton';
 
 interface Election {
   id: number;
@@ -55,7 +56,15 @@ function ElectionDetail() {
     <>
       <NavBar />
       <div style={{padding:'1rem'}}>
-        {!data ? <p>Loading...</p> : (
+        {!data ? (
+          <div>
+            <h2><Skeleton width={120} height={20} /></h2>
+            <p><Skeleton width={220} height={16} /></p>
+            <p><Skeleton width={180} height={16} /></p>
+            <p><Skeleton width={180} height={16} /></p>
+            <p><Skeleton width={180} height={16} /></p>
+          </div>
+        ) : (
           <div>
             <h2>Election {data.id}</h2>
             <p>Meta: {data.meta}</p>

--- a/packages/frontend/src/pages/solana.tsx
+++ b/packages/frontend/src/pages/solana.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip } from 'recharts';
+import Skeleton from '../components/Skeleton';
 
 interface SolanaTally {
   A: number;
@@ -11,6 +12,7 @@ export default function SolanaChart() {
     { option: 'A', votes: 0 },
     { option: 'B', votes: 0 },
   ]);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     const protocol = location.protocol === 'https:' ? 'wss' : 'ws';
@@ -22,6 +24,7 @@ export default function SolanaChart() {
           { option: 'A', votes: msg.A },
           { option: 'B', votes: msg.B },
         ]);
+        setLoading(false);
       } catch {
         // ignore malformed payloads
       }
@@ -31,13 +34,17 @@ export default function SolanaChart() {
 
   return (
     <div style={{ display:'flex',justifyContent:'center',paddingTop:'2rem' }}>
-      <BarChart width={400} height={300} data={data}>
-        <CartesianGrid strokeDasharray="3 3" />
-        <XAxis dataKey="option" />
-        <YAxis allowDecimals={false} />
-        <Tooltip />
-        <Bar dataKey="votes" fill="#8884d8" isAnimationActive={false} />
-      </BarChart>
+      {loading ? (
+        <Skeleton width={400} height={300} />
+      ) : (
+        <BarChart width={400} height={300} data={data}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="option" />
+          <YAxis allowDecimals={false} />
+          <Tooltip />
+          <Bar dataKey="votes" fill="#8884d8" isAnimationActive={false} />
+        </BarChart>
+      )}
     </div>
   );
 }

--- a/packages/frontend/src/styles/globals.css
+++ b/packages/frontend/src/styles/globals.css
@@ -41,3 +41,27 @@ body {
 .switch.off .thumb {
   transform: translateX(0px);
 }
+
+.skeleton {
+  background-color: #e5e7eb;
+  border-radius: 4px;
+}
+.shimmer {
+  position: relative;
+  overflow: hidden;
+}
+.shimmer::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: -150%;
+  width: 50%;
+  height: 100%;
+  background: linear-gradient(90deg, transparent, rgba(255,255,255,0.7), transparent);
+  animation: shimmer 1.2s infinite;
+}
+@keyframes shimmer {
+  100% {
+    transform: translateX(300%);
+  }
+}


### PR DESCRIPTION
## Summary
- add generic `<Skeleton>` component
- style skeleton shimmer effect
- display skeleton rows on dashboard while loading
- show skeleton placeholders for election details
- render chart skeleton before websocket data arrives

## Testing
- `yarn test`
- `cd packages/frontend && yarn install && yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68414c6595ac83279675c90dc2e86d01