### PR TITLE
Implement UX-08 accessibility improvements

### DIFF
--- a/packages/frontend/src/components/MockLoginModal.tsx
+++ b/packages/frontend/src/components/MockLoginModal.tsx
@@ -1,10 +1,35 @@
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useAuth } from '../lib/AuthProvider';
 
 export default function MockLoginModal({ onClose }: { onClose: () => void }) {
   const { login } = useAuth();
   const [email, setEmail] = useState('');
   const [error, setError] = useState('');
+  const emailRef = useRef<HTMLInputElement>(null);
+  const submitRef = useRef<HTMLButtonElement>(null);
+  const cancelRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    emailRef.current?.focus();
+    const trap = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') { onClose(); }
+      if (e.key === 'Tab') {
+        const focusables = [emailRef.current, submitRef.current, cancelRef.current].filter(Boolean) as HTMLElement[];
+        const first = focusables[0];
+        const last = focusables[focusables.length - 1];
+        if (!document.activeElement) return;
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+    document.addEventListener('keydown', trap);
+    return () => document.removeEventListener('keydown', trap);
+  }, [onClose]);
 
   const submit = async () => {
     if (!/^[^@]+@[^@]+\.[^@]+$/.test(email)) { setError('invalid email'); return; }
@@ -19,13 +44,46 @@ export default function MockLoginModal({ onClose }: { onClose: () => void }) {
   };
 
   return (
-    <div style={{position:'fixed',top:0,left:0,right:0,bottom:0,background:'rgba(0,0,0,0.5)',display:'flex',alignItems:'center',justifyContent:'center'}}>
-      <div style={{background:'white',padding:'1rem',minWidth:'300px'}}>
-        <h3>Mock Login</h3>
-        <input type="email" value={email} onChange={e=>setEmail(e.target.value)} placeholder="Email" />
-        <button onClick={submit}>Login</button>
-        <button onClick={onClose}>Cancel</button>
-        {error && <p style={{color:'red'}}>{error}</p>}
+    <div
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        background: 'rgba(0,0,0,0.5)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="mocklogin-title"
+        style={{ background: 'white', padding: '1rem', minWidth: '300px' }}
+      >
+        <h3 id="mocklogin-title">Mock Login</h3>
+        <label htmlFor="mock-email" style={{ display: 'block' }}>
+          Email
+        </label>
+        <input
+          id="mock-email"
+          ref={emailRef}
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="Email"
+        />
+        <div style={{ display: 'flex', gap: '0.5rem', marginTop: '0.5rem' }}>
+          <button ref={submitRef} onClick={submit} aria-label="Submit mock login">
+            Login
+          </button>
+          <button ref={cancelRef} onClick={onClose} aria-label="Cancel mock login">
+            Cancel
+          </button>
+        </div>
+        {error && <p style={{ color: 'red' }}>{error}</p>}
       </div>
     </div>
   );

--- a/packages/frontend/src/lib/ToastProvider.tsx
+++ b/packages/frontend/src/lib/ToastProvider.tsx
@@ -16,9 +16,35 @@ export function ToastProvider({ children }: { children: ReactNode }) {
   return (
     <ToastContext.Provider value={{ showToast }}>
       {children}
-      <div style={{position:'fixed',bottom:'1rem',right:'1rem',display:'flex',flexDirection:'column',gap:'0.5rem',zIndex:1000}}>
-        {toasts.map(t => (
-          <div key={t.id} style={{padding:'0.5rem 1rem',border:'1px solid',borderRadius:'4px',background:'white',color:t.type==='error'?'red':t.type==='success'?'green':'black'}}>
+      <div
+        style={{
+          position: 'fixed',
+          bottom: '1rem',
+          right: '1rem',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '0.5rem',
+          zIndex: 1000,
+        }}
+        aria-live="assertive"
+      >
+        {toasts.map((t) => (
+          <div
+            key={t.id}
+            role="alert"
+            style={{
+              padding: '0.5rem 1rem',
+              border: '1px solid',
+              borderRadius: '4px',
+              background: 'white',
+              color:
+                t.type === 'error'
+                  ? 'red'
+                  : t.type === 'success'
+                  ? 'green'
+                  : 'black',
+            }}
+          >
             {t.message}
           </div>
         ))}

--- a/packages/frontend/src/pages/login.tsx
+++ b/packages/frontend/src/pages/login.tsx
@@ -38,10 +38,26 @@ export default function LoginPage() {
   return (
     <>
       <NavBar />
-      <div style={{display:'flex',flexDirection:'column',alignItems:'center',gap:'1rem',padding:'2rem'}}>
-        <button onClick={startLogin}>Log in with eID</button>
-        <button onClick={openMock}>Mock Login (developer mode)</button>
-      </div>
+      <main
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: '1rem',
+          padding: '2rem',
+        }}
+      >
+        <h1 style={{ fontSize: '1.5rem' }}>Login</h1>
+        <button onClick={startLogin} aria-label="Log in with national eID">
+          Log in with eID
+        </button>
+        <button
+          onClick={openMock}
+          aria-label="Open developer mock login"
+        >
+          Mock Login (developer mode)
+        </button>
+      </main>
       {showMock && <MockLoginModal onClose={() => setShowMock(false)} />}
     </>
   );


### PR DESCRIPTION
## Summary
- make login page accessible with labels and heading
- add focus trap and ARIA attributes to MockLoginModal
- mark toast messages as alerts for screen readers

## Testing
- `pytest -q`
- `npm --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684152c831748327b21607eaeecb5acc