### PR TITLE
Add CORS header to /auth/initiate

### DIFF
--- a/packages/backend/main.py
+++ b/packages/backend/main.py
@@ -28,6 +28,7 @@ app = FastAPI()
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["http://localhost:3000"],
+    allow_origin_regex=".*",
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
@@ -109,9 +110,9 @@ def initiate():
             f"response_type=code&client_id={CLIENT_ID}"
             f"&redirect_uri={REDIRECT}&scope=openid email"
         )
-        return RedirectResponse(url)
-
-    html = """
+        response = RedirectResponse(url)
+    else:
+        html = """
     <html>
       <body>
         <h1>Mock Login</h1>
@@ -122,7 +123,10 @@ def initiate():
       </body>
     </html>
     """
-    return HTMLResponse(html)
+        response = HTMLResponse(html)
+
+    response.headers["Access-Control-Allow-Origin"] = "*"
+    return response
 
 @app.get("/auth/callback")
 async def callback(code: Optional[str] = None, user: Optional[str] = None):

--- a/packages/backend/tests/test_main.py
+++ b/packages/backend/tests/test_main.py
@@ -57,6 +57,7 @@ def test_mock_login_and_list():
     r = client.get("/auth/initiate")
     assert r.status_code == 200
     assert "Mock Login" in r.text
+    assert r.headers["access-control-allow-origin"] == "*"
 
     # callback returns fake JWT
     r = client.get("/auth/callback", params={"user": "alice@example.com"})


### PR DESCRIPTION
## Summary
- broaden CORS middleware
- add explicit `Access-Control-Allow-Origin` header in `/auth/initiate`
- verify header in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684163f005688327aa39f38c98b3a7a4