### PR TITLE
Add /auth/callback handler

### DIFF
--- a/packages/backend/main.py
+++ b/packages/backend/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, HTTPException, Depends, Header, WebSocket
+from fastapi import FastAPI, HTTPException, Depends, Header, WebSocket, Request
 from datetime import datetime
 from fastapi.responses import RedirectResponse, HTMLResponse
 from fastapi.middleware.cors import CORSMiddleware
@@ -33,6 +33,13 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# Always expose CORS header even without Origin
+@app.middleware("http")
+async def add_cors_header(request: Request, call_next):
+    response = await call_next(request)
+    response.headers.setdefault("access-control-allow-origin", "*")
+    return response
 
 # On-chain ElectionManager config
 EVM_RPC = os.getenv("EVM_RPC", "http://127.0.0.1:8545")

--- a/packages/frontend/src/pages/auth/callback.tsx
+++ b/packages/frontend/src/pages/auth/callback.tsx
@@ -1,0 +1,29 @@
+import React, { useEffect } from 'react';
+import { useRouter } from 'next/router';
+
+export default function CallbackPage() {
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!router.isReady) return;
+    if (!window.opener) {
+      router.replace('/login');
+      return;
+    }
+    const query = window.location.search;
+    fetch(`http://localhost:8000/auth/callback${query}`)
+      .then(r => r.ok ? r.json() : Promise.reject(r.statusText))
+      .then(data => {
+        window.opener.postMessage({ id_token: data.id_token, eligibility: data.eligibility }, 'http://localhost:3000');
+        window.close();
+      })
+      .catch(() => {
+        window.opener.postMessage({ error: true }, 'http://localhost:3000');
+        window.close();
+      });
+  }, [router.isReady]);
+
+  return (
+    <p style={{padding:'1rem'}}>Processing...</p>
+  );
+}


### PR DESCRIPTION
## Summary
- expose CORS header even when no `Origin` header
- add a frontend page at `/auth/callback`

## Testing
- `pytest -q`
- `npx jest --silent`

------
https://chatgpt.com/codex/tasks/task_e_684169d2fbc88327a4ce363dcb1d5a7b