### PR TITLE
Update compose env vars

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,9 @@ services:
       GRAO_CLIENT_SECRET: ${GRAO_CLIENT_SECRET:-test-secret}
       GRAO_REDIRECT_URI: ${GRAO_REDIRECT_URI:-http://localhost:3000/callback}
       USE_REAL_OAUTH: ${USE_REAL_OAUTH:-false}
+      EVM_RPC: http://anvil:8545
+      CELERY_BROKER: redis://redis:6379/0
+      CELERY_BACKEND: redis://redis:6379/0
     ports:
       - "8000:8000"
     depends_on:
@@ -59,6 +62,7 @@ services:
       dockerfile: Dockerfile
     environment:
       EVM_RPC: http://anvil:8545
+      EVM_MAX_RETRIES: "0"
       ELECTION_MANAGER: ${ELECTION_MANAGER:-0x0000000000000000000000000000000000000000}
       ORCHESTRATOR_KEY: ${ORCHESTRATOR_KEY:-0x0000000000000000000000000000000000000000000000000000000000000000}
     volumes:

--- a/docs/handbook/README.md
+++ b/docs/handbook/README.md
@@ -16,6 +16,11 @@ The orchestrator service connects to an EVM JSON‑RPC endpoint. When using
 orchestrator will retry connecting for up to 20 attempts. Set `EVM_RPC` to a
 custom URL or use `EVM_MAX_RETRIES=0` to wait indefinitely.
 
+The backend uses Celery with Redis for proof generation. The Compose
+configuration sets `EVM_RPC` along with `CELERY_BROKER` and
+`CELERY_BACKEND` so it can talk to the `anvil` and `redis` services. If you
+run the backend on its own, provide these variables manually.
+
 The frontend will be available on `http://localhost:3000`, the API on
 `http://localhost:8000` and Postgres on `localhost:5432`.
 


### PR DESCRIPTION
## Summary
- wire backend to redis and anvil
- allow orchestrator to wait indefinitely
- document environment variables for backend

## Testing
- `pip install -q -r packages/backend/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68416cb802a08327a65ff7e8e2e52198