### PR TITLE
Fix election create redirect

### DIFF
--- a/packages/frontend/src/pages/elections/create.tsx
+++ b/packages/frontend/src/pages/elections/create.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useRouter } from 'next/router';
 import { keccak256, toUtf8Bytes } from 'ethers/lib/utils';
 import { useAuth } from '../../lib/AuthProvider';
 import withAuth from '../../components/withAuth';
@@ -7,6 +8,7 @@ import { useToast } from '../../lib/ToastProvider';
 
 function CreateElectionPage() {
   const { token, eligibility } = useAuth();
+  const router = useRouter();
   const [meta, setMeta] = useState('');
   const { showToast } = useToast();
 
@@ -22,7 +24,7 @@ function CreateElectionPage() {
       body: JSON.stringify({ meta_hash: hash }),
     });
     if (res.ok) {
-      window.location.href = '/dashboard';
+      router.push('/dashboard');
     } else {
       showToast({ type: 'error', message: 'Failed to create' });
     }


### PR DESCRIPTION
## Summary
- fix create election page to use Next.js router navigation instead of page reload

## Testing
- `yarn test`
- `pytest packages/backend/tests/test_main.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6841701f12c0832794c49d8bd8e88c25