### PR TITLE
Implement role-aware guards and wizard

### DIFF
--- a/docs/uiux_pbis.md
+++ b/docs/uiux_pbis.md
@@ -24,6 +24,14 @@ The following product backlog items (PBIs) capture upcoming UI and UX work.
 | **UX-16** | **Contextual Help Popovers**      | Small `?` icons next to complex terms (Eligibility, Voice Credits, ZK Proof) that open Tippy.js popovers.                                                         |
 | **UX-17** | **i18n Copy Pass #2**             | Audit new UI strings introduced by UX-01 – UX-16 and add to `en.json` / `bg.json`; ensure plural rules.                                                           |
 
+| **UX-18** | **Role-Aware Nav & Route Guards** | Surface the current RBAC role (admin / user / verifier) in `<AuthProvider>`; update all guards to gate links & pages accordingly. |
+| **UX-19** | **Eligibility Gate Banner** | Inline banner on `/create` and `/eligibility` explains why the user can\'t proceed. |
+| **UX-20** | **Create-Election Wizard** | Replace the single textbox with a 3-step wizard to confirm hash before submit. |
+| **UX-21** | **Optimistic Dashboard Update** | Newly created election appears without full reload. |
+| **UX-22** | **Verifier Panel** | Table of pending proofs visible only for verifier role. |
+| **UX-23** | **Admin → User Role Switcher UI** | Account menu lets an admin change another user\'s role. |
+| **UX-24** | **Universal No-Reload Flow** | Convert remaining page loads to client-side transitions. |
+| **UX-25** | **End-to-End Smoke Flow (FE-only Cypress)** | Cypress runs the full login → eligibility → create flow with no reloads. |
 ## Detailed Acceptance-Criteria
 
 ### UX-01  Dual-Mode Auth Selector

--- a/packages/frontend/__tests__/role.guard.test.js
+++ b/packages/frontend/__tests__/role.guard.test.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import router from 'next-router-mock';
+import NavBar from '../src/components/NavBar';
+import withAuth from '../src/components/withAuth';
+import { AuthProvider } from '../src/lib/AuthProvider';
+
+jest.mock('next/router', () => require('next-router-mock'));
+
+function makeToken(role) {
+  const payload = Buffer.from(JSON.stringify({ role })).toString('base64url');
+  return `a.${payload}.c`;
+}
+
+describe('role based guards', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    router.setCurrentUrl('/');
+  });
+
+  test('admin sees create link', () => {
+    localStorage.setItem('id_token', makeToken('admin'));
+    localStorage.setItem('eligibility', 'true');
+    localStorage.setItem('auth_mode', 'eid');
+    const { getByText } = render(
+      <AuthProvider>
+        <NavBar />
+      </AuthProvider>
+    );
+    expect(getByText('Create Election')).toBeInTheDocument();
+  });
+
+  test('user does not see create link', () => {
+    localStorage.setItem('id_token', makeToken('user'));
+    localStorage.setItem('eligibility', 'true');
+    localStorage.setItem('auth_mode', 'eid');
+    const { queryByText } = render(
+      <AuthProvider>
+        <NavBar />
+      </AuthProvider>
+    );
+    expect(queryByText('Create Election')).toBeNull();
+  });
+
+  test('forbidden route shows 403', () => {
+    localStorage.setItem('id_token', makeToken('user'));
+    localStorage.setItem('eligibility', 'true');
+    localStorage.setItem('auth_mode', 'eid');
+    const Protected = withAuth(() => <p>secret</p>, ['verifier']);
+    const { getByText } = render(
+      <AuthProvider>
+        <Protected />
+      </AuthProvider>
+    );
+    expect(getByText(/403/)).toBeInTheDocument();
+  });
+});

--- a/packages/frontend/src/components/Forbidden.tsx
+++ b/packages/frontend/src/components/Forbidden.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export default function Forbidden() {
+  return (
+    <div style={{padding:'2rem',textAlign:'center'}}>
+      <h1>403 Forbidden</h1>
+      <p>You do not have access to this page.</p>
+    </div>
+  );
+}

--- a/packages/frontend/src/components/GateBanner.tsx
+++ b/packages/frontend/src/components/GateBanner.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function GateBanner({ message, href, label }: { message: string; href: string; label: string }) {
+  return (
+    <div style={{marginBottom:'1rem',padding:'0.5rem 1rem',border:'1px solid',borderRadius:'4px',background:'white',color:'red'}}>
+      {message} <a href={href}>{label}</a>
+    </div>
+  );
+}

--- a/packages/frontend/src/components/NavBar.tsx
+++ b/packages/frontend/src/components/NavBar.tsx
@@ -6,7 +6,7 @@ import AuthChip from './AuthChip';
 import AccountMenu from './AccountMenu';
 
 export default function NavBar() {
-  const { isLoggedIn, eligibility, logout } = useAuth();
+  const { isLoggedIn, eligibility, logout, role } = useAuth();
   const [open, setOpen] = useState(false);
 
   const links = (
@@ -16,6 +16,9 @@ export default function NavBar() {
         <>
           <Link href="/dashboard">Dashboard</Link>
           {eligibility && <Link href="/eligibility">Eligibility</Link>}
+          {(role === 'admin' || role === 'verifier') && (
+            <Link href="/elections/create">Create Election</Link>
+          )}
         </>
       )}
     </>

--- a/packages/frontend/src/components/withAuth.tsx
+++ b/packages/frontend/src/components/withAuth.tsx
@@ -1,15 +1,20 @@
 import { useRouter } from 'next/router';
-import { useAuth } from '../lib/AuthProvider';
+import { useAuth, Role } from '../lib/AuthProvider';
 import { useEffect } from 'react';
+import Forbidden from './Forbidden';
 
-export default function withAuth(Component: React.ComponentType<any>): React.FC<any> {
+export default function withAuth(
+  Component: React.ComponentType<any>,
+  roles: Role[] = ['admin', 'user', 'verifier']
+): React.FC<any> {
   return function Protected(props: any) {
-    const { isLoggedIn } = useAuth();
+    const { isLoggedIn, role } = useAuth();
     const router = useRouter();
     useEffect(() => {
       if (!isLoggedIn) router.replace('/login');
     }, [isLoggedIn, router]);
     if (!isLoggedIn) return null;
+    if (!roles.includes(role)) return <Forbidden />;
     return <Component {...props} />;
   };
 }

--- a/packages/frontend/src/pages/elections/create.tsx
+++ b/packages/frontend/src/pages/elections/create.tsx
@@ -2,19 +2,23 @@ import { useState } from 'react';
 import { useRouter } from 'next/router';
 import { keccak256, toUtf8Bytes } from 'ethers/lib/utils';
 import { useAuth } from '../../lib/AuthProvider';
-import withAuth from '../../components/withAuth';
 import NavBar from '../../components/NavBar';
 import { useToast } from '../../lib/ToastProvider';
+import GateBanner from '../../components/GateBanner';
 
 function CreateElectionPage() {
-  const { token, eligibility } = useAuth();
+  const { token, eligibility, role, isLoggedIn } = useAuth();
   const router = useRouter();
+  const step = parseInt((router.query.step as string) || '1', 10);
   const [meta, setMeta] = useState('');
+  const [hash, setHash] = useState('');
+  const [loading, setLoading] = useState(false);
   const { showToast } = useToast();
 
-  const submit = async () => {
-    if (!eligibility) return;
-    const hash = keccak256(toUtf8Bytes(meta));
+  const goto = (n: number) => router.replace(`/elections/create?step=${n}`);
+
+  const handleSubmit = async () => {
+    setLoading(true);
     const res = await fetch('http://localhost:8000/elections', {
       method: 'POST',
       headers: {
@@ -24,24 +28,80 @@ function CreateElectionPage() {
       body: JSON.stringify({ meta_hash: hash }),
     });
     if (res.ok) {
-      router.push('/dashboard');
+      const data = await res.json();
+      router.push(`/elections/${data.id}`);
     } else {
       showToast({ type: 'error', message: 'Failed to create' });
     }
+    setLoading(false);
   };
 
-  if (!eligibility) return <p>Not authorized</p>;
+  if (!isLoggedIn) {
+    return (
+      <>
+        <NavBar />
+        <div style={{padding:'1rem'}}>
+          <GateBanner message="You must log in first." href="/login" label="Log in" />
+        </div>
+      </>
+    );
+  }
+
+  if (role !== 'admin' && role !== 'verifier') {
+    return (
+      <>
+        <NavBar />
+        <div style={{padding:'1rem'}}>
+          <GateBanner message="Insufficient role." href="/dashboard" label="Back" />
+        </div>
+      </>
+    );
+  }
+
+  if (!eligibility) {
+    return (
+      <>
+        <NavBar />
+        <div style={{padding:'1rem'}}>
+          <GateBanner message="Provide an eligibility proof first." href="/eligibility" label="Prove" />
+        </div>
+      </>
+    );
+  }
+
+  const stepOne = (
+    <div style={{display:'flex',flexDirection:'column',gap:'0.5rem'}}>
+      <textarea value={meta} onChange={e => setMeta(e.target.value)} placeholder="metadata json" />
+      <button onClick={() => { setHash(keccak256(toUtf8Bytes(meta))); goto(2); }}>Next</button>
+    </div>
+  );
+
+  const stepTwo = (
+    <div style={{display:'flex',flexDirection:'column',gap:'0.5rem'}}>
+      <p>Hash: {hash}</p>
+      <button onClick={() => goto(1)}>Back</button>
+      <button onClick={() => goto(3)}>Confirm</button>
+    </div>
+  );
+
+  const stepThree = (
+    <div style={{display:'flex',flexDirection:'column',gap:'0.5rem'}}>
+      <button onClick={handleSubmit} disabled={loading}>Submit</button>
+      <button onClick={() => router.push('/dashboard')}>Cancel</button>
+    </div>
+  );
 
   return (
     <>
       <NavBar />
       <div style={{padding:'1rem'}}>
         <h2>Create Election</h2>
-        <input value={meta} onChange={e => setMeta(e.target.value)} placeholder="metadata" />
-        <button onClick={submit}>Submit</button>
+        {step === 1 && stepOne}
+        {step === 2 && stepTwo}
+        {step === 3 && stepThree}
       </div>
     </>
   );
 }
 
-export default withAuth(CreateElectionPage);
+export default CreateElectionPage;

--- a/packages/frontend/src/pages/eligibility.tsx
+++ b/packages/frontend/src/pages/eligibility.tsx
@@ -1,14 +1,14 @@
 import React, { useState } from 'react';
-import withAuth from '../components/withAuth';
 import NavBar from '../components/NavBar';
 import { useAuth } from '../lib/AuthProvider';
+import GateBanner from '../components/GateBanner';
 import { useToast } from '../lib/ToastProvider';
 import ProgressOverlay from '../components/ProgressOverlay';
 import { NoProofs } from '../components/ZeroState';
 import HelpTip from '../components/HelpTip';
 
 function EligibilityPage() {
-  const { token } = useAuth();
+  const { token, isLoggedIn } = useAuth();
   const [country, setCountry] = useState('');
   const [dob, setDob] = useState('');
   const [residency, setResidency] = useState('');
@@ -58,6 +58,9 @@ function EligibilityPage() {
     <>
       <NavBar />
       <div style={{padding:'1rem'}}>
+        {!isLoggedIn && (
+          <GateBanner message="You must log in to prove eligibility." href="/login" label="Log in" />
+        )}
         <h2>Eligibility Proof <HelpTip content="Proves you meet the election rules" /></h2>
         <div>
           <label>Country: <input value={country} onChange={e => setCountry(e.target.value)} /></label>
@@ -68,7 +71,7 @@ function EligibilityPage() {
         <div>
           <label>Residency: <input value={residency} onChange={e => setResidency(e.target.value)} /></label>
         </div>
-        <button onClick={submit} disabled={loading}>Submit</button>
+        <button onClick={submit} disabled={loading || !isLoggedIn}>Submit</button>
         {proof ? <p>Proof: {proof}</p> : !loading && <NoProofs />}
         {loading && overlay}
       </div>
@@ -76,4 +79,4 @@ function EligibilityPage() {
   );
 }
 
-export default withAuth(EligibilityPage);
+export default EligibilityPage;


### PR DESCRIPTION
## Summary
- document PBIs UX-18 to UX-25
- surface user role in `AuthProvider`
- add Forbidden and GateBanner components
- update `withAuth` and `NavBar` with role checks
- add create-election wizard with stepper
- show login banner on eligibility page
- unit tests for role logic

## Testing
- `npm test`
- `(cd packages/frontend && npm test)`

------
https://chatgpt.com/codex/tasks/task_e_684188b286f483279de0b7ac7c0c754a