### PR TITLE
Implement UX-23 role switcher

### DIFF
--- a/packages/frontend/__tests__/account.menu.test.js
+++ b/packages/frontend/__tests__/account.menu.test.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import router from 'next-router-mock';
+import AccountMenu from '../src/components/AccountMenu';
+import { AuthProvider } from '../src/lib/AuthProvider';
+import { I18nProvider } from '../src/lib/I18nProvider';
+
+jest.mock('next/router', () => require('next-router-mock'));
+
+function makeToken(role) {
+  const payload = Buffer.from(JSON.stringify({ role })).toString('base64url');
+  return `a.${payload}.c`;
+}
+
+describe('account menu role switcher', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    router.setCurrentUrl('/');
+  });
+
+  test('admin sees role switch option', () => {
+    localStorage.setItem('id_token', makeToken('admin'));
+    localStorage.setItem('eligibility', 'true');
+    localStorage.setItem('auth_mode', 'eid');
+    const { getByLabelText, getByText } = render(
+      <I18nProvider>
+        <AuthProvider>
+          <AccountMenu />
+        </AuthProvider>
+      </I18nProvider>
+    );
+    fireEvent.click(getByLabelText('Account menu'));
+    expect(getByText('Change User Role')).toBeInTheDocument();
+  });
+
+  test('user does not see role switch option', () => {
+    localStorage.setItem('id_token', makeToken('user'));
+    localStorage.setItem('eligibility', 'true');
+    localStorage.setItem('auth_mode', 'eid');
+    const { getByLabelText, queryByText } = render(
+      <I18nProvider>
+        <AuthProvider>
+          <AccountMenu />
+        </AuthProvider>
+      </I18nProvider>
+    );
+    fireEvent.click(getByLabelText('Account menu'));
+    expect(queryByText('Change User Role')).toBeNull();
+  });
+});

--- a/packages/frontend/src/components/AccountMenu.tsx
+++ b/packages/frontend/src/components/AccountMenu.tsx
@@ -2,11 +2,13 @@ import { useState } from 'react';
 import { useAuth } from '../lib/AuthProvider';
 import ThemeToggle from './ThemeToggle';
 import { useI18n } from '../lib/I18nProvider';
+import RoleSwitchModal from './RoleSwitchModal';
 
 export default function AccountMenu() {
-  const { logout, mode, setMode } = useAuth();
+  const { logout, mode, setMode, role } = useAuth();
   const { t } = useI18n();
   const [open, setOpen] = useState(false);
+  const [showRole, setShowRole] = useState(false);
 
   const toggleMode = () => {
     setMode(mode === 'mock' ? 'eid' : 'mock');
@@ -21,9 +23,13 @@ export default function AccountMenu() {
         <div style={{ position:'absolute', right:0, marginTop:'0.5rem', background:'var(--bg)', border:'1px solid var(--muted)', borderRadius:'4px', padding:'0.5rem', display:'flex', flexDirection:'column', gap:'0.5rem' }}>
           <button onClick={logout}>{t('account.logout')}</button>
           <button onClick={toggleMode}>{t('account.switch')}</button>
+          {role === 'admin' && (
+            <button onClick={() => setShowRole(true)}>{t('account.role')}</button>
+          )}
           <ThemeToggle />
         </div>
       )}
+      {showRole && <RoleSwitchModal onClose={() => setShowRole(false)} />}
     </div>
   );
 }

--- a/packages/frontend/src/components/RoleSwitchModal.tsx
+++ b/packages/frontend/src/components/RoleSwitchModal.tsx
@@ -1,0 +1,92 @@
+import { useState, useEffect, useRef } from 'react';
+import { useAuth } from '../lib/AuthProvider';
+import { useToast } from '../lib/ToastProvider';
+import { useI18n } from '../lib/I18nProvider';
+
+export default function RoleSwitchModal({ onClose }: { onClose: () => void }) {
+  const { token } = useAuth();
+  const { showToast } = useToast();
+  const { t } = useI18n();
+  const [email, setEmail] = useState('');
+  const [role, setRole] = useState<'admin' | 'user' | 'verifier'>('user');
+  const emailRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    emailRef.current?.focus();
+  }, []);
+
+  const submit = async () => {
+    const res = await fetch(
+      `http://localhost:8000/admin/users/${encodeURIComponent(email)}`,
+      {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ role }),
+      },
+    );
+    if (res.ok) {
+      showToast({ type: 'success', message: t('account.roleChanged') });
+      onClose();
+    } else {
+      showToast({ type: 'error', message: t('account.roleFailed') });
+    }
+  };
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        background: 'rgba(0,0,0,0.5)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        style={{ background: 'white', padding: '1rem', minWidth: '300px' }}
+      >
+        <h3>{t('account.role')}</h3>
+        <label htmlFor="role-email" style={{ display: 'block' }}>
+          Email
+        </label>
+        <input
+          id="role-email"
+          ref={emailRef}
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="user@example.com"
+        />
+        <label htmlFor="role-select" style={{ display: 'block', marginTop: '0.5rem' }}>
+          Role
+        </label>
+        <select
+          id="role-select"
+          value={role}
+          onChange={(e) => setRole(e.target.value as any)}
+        >
+          <option value="user">user</option>
+          <option value="verifier">verifier</option>
+          <option value="admin">admin</option>
+        </select>
+        <div style={{ display: 'flex', gap: '0.5rem', marginTop: '0.5rem' }}>
+          <button onClick={submit} aria-label="Submit role change">
+            Submit
+          </button>
+          <button onClick={onClose} aria-label="Cancel role change">
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend/src/translations/bg.json
+++ b/packages/frontend/src/translations/bg.json
@@ -3,5 +3,8 @@
   "login.retryBtn": "Опитай отново",
   "login.switch": "Превключи към макет",
   "account.logout": "Изход",
-  "account.switch": "Смени метода"
+  "account.switch": "Смени метода",
+  "account.role": "Смяна на роля",
+  "account.roleChanged": "Ролята е обновена",
+  "account.roleFailed": "Неуспешна смяна"
 }

--- a/packages/frontend/src/translations/en.json
+++ b/packages/frontend/src/translations/en.json
@@ -3,5 +3,8 @@
   "login.retryBtn": "Retry",
   "login.switch": "Switch to Mock",
   "account.logout": "Logout",
-  "account.switch": "Switch Login Method"
+  "account.switch": "Switch Login Method",
+  "account.role": "Change User Role",
+  "account.roleChanged": "Role updated",
+  "account.roleFailed": "Failed to update"
 }


### PR DESCRIPTION
## Summary
- add RoleSwitchModal for admins to modify other users
- update AccountMenu to open the role switcher
- translate new menu entry
- test AccountMenu role switcher visibility

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_68418b2eb41883279b2ae58290d2c03d