### PR TITLE
Implement UX-24 no‑reload flow and Cypress smoke test

### DIFF
--- a/docs/uiux_pbis.md
+++ b/docs/uiux_pbis.md
@@ -106,3 +106,22 @@ UX-11–UX-17 can run once core flows (UX-01 … UX-10) are merged.
 ```
 
 
+### UX-24  Universal No-Reload Flow
+
+* **Scope**: Replace the remaining full page loads with client-side routing via `next/link` or `router.push`.
+* **Pages Affected**: `/`, `/dashboard`, `/elections/[id]`, `/elections/create`, `/eligibility`.
+* **Acceptance Criteria**
+  * Navigating between these pages does not create additional `navigation` entries in `window.performance`.
+  * All call-to-action buttons use client-side links.
+* **Dependencies**: UX-21.
+
+### UX-25  End-to-End Smoke Flow (FE-only Cypress)
+
+* **Tooling**: Cypress 13, executed in the frontend package via `yarn test:e2e`.
+* **Flow**:
+  1. Start from `/` and navigate to the Solana chart.
+  2. Use the navbar to open the login page.
+  3. Assert that `performance.getEntriesByType('navigation').length` remains `1` throughout.
+* **CI**: run the Cypress smoke test on pull requests.
+* **Dependencies**: UX-24 must be complete.
+

--- a/packages/frontend/cypress.config.ts
+++ b/packages/frontend/cypress.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'cypress';
+
+export default defineConfig({
+  e2e: {
+    baseUrl: 'http://localhost:3000',
+    supportFile: false,
+  },
+});

--- a/packages/frontend/cypress/e2e/smoke.cy.js
+++ b/packages/frontend/cypress/e2e/smoke.cy.js
@@ -1,0 +1,18 @@
+describe('smoke flow without reloads', () => {
+  it('navigates via client-side links', () => {
+    cy.visit('/');
+    cy.window().then((win) => {
+      expect(win.performance.getEntriesByType('navigation').length).to.eq(1);
+    });
+    cy.contains('View Solana Chart').click();
+    cy.url().should('include', '/solana');
+    cy.window().then((win) => {
+      expect(win.performance.getEntriesByType('navigation').length).to.eq(1);
+    });
+    cy.get('nav a[href="/login"]').click();
+    cy.url().should('include', '/login');
+    cy.window().then((win) => {
+      expect(win.performance.getEntriesByType('navigation').length).to.eq(1);
+    });
+  });
+});

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -6,7 +6,8 @@
     "build": "next build",
     "start": "next start",
     "type-check": "tsc --noEmit",
-    "test": "jest"
+    "test": "jest",
+    "test:e2e": "cypress run"
   },
   "dependencies": {
     "@account-abstraction/sdk": "^0.6.0",
@@ -34,7 +35,8 @@
     "jest-environment-jsdom": "^29.7.0",
     "next-router-mock": "^1.0.2",
     "ts-jest": "^29.1.1",
-    "typescript": "^4.9.0"
+    "typescript": "^4.9.0",
+    "cypress": "^13.7.0"
   },
   "packageManager": "yarn@1.22.22"
 }

--- a/packages/frontend/src/components/GateBanner.tsx
+++ b/packages/frontend/src/components/GateBanner.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
+import Link from 'next/link';
 
 export default function GateBanner({ message, href, label }: { message: string; href: string; label: string }) {
   return (
     <div style={{marginBottom:'1rem',padding:'0.5rem 1rem',border:'1px solid',borderRadius:'4px',background:'white',color:'red'}}>
-      {message} <a href={href}>{label}</a>
+      {message} <Link href={href}>{label}</Link>
     </div>
   );
 }

--- a/packages/frontend/src/lib/AuthProvider.tsx
+++ b/packages/frontend/src/lib/AuthProvider.tsx
@@ -98,9 +98,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     localStorage.removeItem('id_token');
     localStorage.removeItem('eligibility');
     localStorage.removeItem('auth_mode');
-    if (typeof window !== 'undefined') {
-      window.location.href = '/';
-    }
+    router.replace('/');
   };
 
   return (

--- a/packages/frontend/src/pages/dashboard.tsx
+++ b/packages/frontend/src/pages/dashboard.tsx
@@ -2,6 +2,7 @@ import useSWR from 'swr';
 import { useAuth } from '../lib/AuthProvider';
 import withAuth from '../components/withAuth';
 import NavBar from '../components/NavBar';
+import Link from 'next/link';
 import Skeleton from '../components/Skeleton';
 import { NoElections } from '../components/ZeroState';
 
@@ -34,7 +35,7 @@ function DashboardPage() {
     <>
       <NavBar />
       <div style={{padding:'1rem'}}>
-        {eligibility && <a href="/elections/create">Create Election</a>}
+        {eligibility && <Link href="/elections/create">Create Election</Link>}
         <h2>Election List</h2>
         {!data ? (
           <table>
@@ -63,7 +64,7 @@ function DashboardPage() {
             <tbody>
               {data.map(e => (
                 <tr key={e.id}>
-                  <td><a href={`/elections/${e.id}`}>{e.id}</a></td>
+                  <td><Link href={`/elections/${e.id}`}>{e.id}</Link></td>
                   <td>{e.meta}</td>
                   <td>{e.start}</td>
                   <td>{e.end}</td>

--- a/packages/frontend/src/pages/elections/[id].tsx
+++ b/packages/frontend/src/pages/elections/[id].tsx
@@ -1,6 +1,7 @@
 import { useRouter } from 'next/router';
 import useSWR from 'swr';
 import { useState } from 'react';
+import Link from 'next/link';
 import NavBar from '../../components/NavBar';
 import withAuth from '../../components/withAuth';
 import { useAuth } from '../../lib/AuthProvider';
@@ -73,7 +74,7 @@ function ElectionDetail() {
             <p>Status: {data.status}</p>
             {data.tally && <p>Tally: {data.tally}</p>}
             {data.status === 'open' && eligibility && (
-              <a href={`/vote?id=${data.id}`}>Vote</a>
+              <Link href={`/vote?id=${data.id}`}>Vote</Link>
             )}
             {data.status !== 'open' && eligibility && (
               <button onClick={() => alert('run tally placeholder')}>Run Tally</button>

--- a/packages/frontend/src/pages/index.jsx
+++ b/packages/frontend/src/pages/index.jsx
@@ -1,6 +1,7 @@
 import ThemeToggle from '../components/ThemeToggle';
 import GasFeeEstimator from '../components/GasFeeEstimator';
 import NavBar from '../components/NavBar';
+import Link from 'next/link';
 
 export default function Home() {
   return (
@@ -8,7 +9,7 @@ export default function Home() {
       <NavBar />
       <main style={{ display:'flex',alignItems:'center',justifyContent:'center',height:'80vh', gap:'1rem' }}>
         <ThemeToggle />
-        <a href="/solana">View Solana Chart</a>
+        <Link href="/solana">View Solana Chart</Link>
         <div>Gas: <GasFeeEstimator /></div>
       </main>
     </>


### PR DESCRIPTION
## Summary
- update docs with UX-24/25 details
- switch all internal anchors to Next.js `Link`
- use router navigation on logout
- add Cypress configuration and smoke E2E test

## Testing
- `yarn test` *(backend tsc)*
- `yarn test` in `packages/frontend` *(fails: jest not found)*
- `yarn test:e2e` in `packages/frontend` *(fails: cypress not found)*

------
https://chatgpt.com/codex/tasks/task_e_68418d43a53883278d639c87de79508a