### PR TITLE
Fix login redirect timing

### DIFF
--- a/packages/frontend/src/components/withAuth.tsx
+++ b/packages/frontend/src/components/withAuth.tsx
@@ -1,6 +1,5 @@
 import { useRouter } from 'next/router';
 import { useAuth, Role } from '../lib/AuthProvider';
-import { useEffect } from 'react';
 import Forbidden from './Forbidden';
 
 export default function withAuth(
@@ -8,12 +7,10 @@ export default function withAuth(
   roles: Role[] = ['admin', 'user', 'verifier']
 ): React.FC<any> {
   return function Protected(props: any) {
-    const { isLoggedIn, role } = useAuth();
+    const { isLoggedIn, role, ready } = useAuth();
     const router = useRouter();
-    useEffect(() => {
-      if (!isLoggedIn) router.replace('/login');
-    }, [isLoggedIn, router]);
-    if (!isLoggedIn) return null;
+    if (!ready) return null;
+    if (!isLoggedIn) { router.replace('/login'); return null; }
     if (!roles.includes(role)) return <Forbidden />;
     return <Component {...props} />;
   };

--- a/packages/frontend/src/lib/AuthProvider.tsx
+++ b/packages/frontend/src/lib/AuthProvider.tsx
@@ -11,6 +11,7 @@ interface AuthContextValue {
   isLoggedIn: boolean;
   mode: AuthMode;
   role: Role;
+  ready: boolean;
   setMode: (m: AuthMode) => void;
   login: (token: string, eligibility: boolean, mode: AuthMode) => void;
   logout: () => void;
@@ -22,6 +23,7 @@ const AuthContext = createContext<AuthContextValue>({
   isLoggedIn: false,
   mode: 'guest',
   role: 'user',
+  ready: false,
   setMode: () => {},
   login: () => {},
   logout: () => {},
@@ -50,6 +52,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [eligibility, setEligibility] = useState<boolean>(false);
   const [mode, setMode] = useState<AuthMode>('guest');
   const [role, setRole] = useState<Role>('user');
+  const [ready, setReady] = useState<boolean>(false);
   const router = useRouter();
 
   useEffect(() => {
@@ -76,6 +79,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       }
     };
     window.addEventListener('message', handler);
+    setReady(true);
     return () => window.removeEventListener('message', handler);
   }, []);
 
@@ -102,7 +106,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   };
 
   return (
-    <AuthContext.Provider value={{ token, eligibility, isLoggedIn: !!token, mode, role, setMode, login, logout }}>
+    <AuthContext.Provider value={{ token, eligibility, isLoggedIn: !!token, mode, role, ready, setMode, login, logout }}>
       {children}
     </AuthContext.Provider>
   );


### PR DESCRIPTION
## Summary
- avoid login redirect loop by waiting for auth to finish loading

## Testing
- `npm test --prefix packages/frontend`

------
https://chatgpt.com/codex/tasks/task_e_6841f059d55c832782f3aa009d810d5e