### PR TITLE
Fix contract issues and add tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,7 @@
 ### Added
 - `ElectionManagerV2` upgradeable via UUPS proxy.
 - `submitTypedBallot` EIP-712 support in `QVManager`.
+### Fixed
+- Persist tally results on-chain in `ElectionManagerV2`.
+- Replay protection for ballots in `QVManager`.
+- `WalletFactory` restricts one wallet per owner.

--- a/contracts/ElectionManagerV2.sol
+++ b/contracts/ElectionManagerV2.sol
@@ -15,7 +15,7 @@ interface IMACI {
 contract ElectionManagerV2 is Initializable, UUPSUpgradeable, OwnableUpgradeable {
     IMACI public maci;
     TallyVerifier public tallyVerifier;
-    bool public tallied;
+    bool public tallied; // slot from V1
 
     struct Election {
         uint256 start;
@@ -24,6 +24,7 @@ contract ElectionManagerV2 is Initializable, UUPSUpgradeable, OwnableUpgradeable
 
     mapping(uint256 => Election) public elections;
     uint256 public nextId;
+    uint256[2] public result; // [A, B] tally result
 
     /// @dev initializer replaces constructor for upgradeable contracts
     function initialize(IMACI _maci) public initializer {
@@ -60,7 +61,12 @@ contract ElectionManagerV2 is Initializable, UUPSUpgradeable, OwnableUpgradeable
         uint256[7] calldata pubSignals
     ) external onlyOwner {
         require(!tallied, "already tallied");
-        require(tallyVerifier.verifyProof(a, b, c, pubSignals), "invalid tally proof");
+        require(
+            tallyVerifier.verifyProof(a, b, c, pubSignals),
+            "invalid tally proof"
+        );
+        result[0] = pubSignals[0];
+        result[1] = pubSignals[1];
         emit Tally(pubSignals[0], pubSignals[1]);
         tallied = true;
     }

--- a/contracts/QVManager.sol
+++ b/contracts/QVManager.sol
@@ -12,6 +12,7 @@ import {ECDSA} from "openzeppelin-contracts/contracts/utils/cryptography/ECDSA.s
 contract QVManager is EIP712 {
     IMACI public immutable maci;
     QVVerifier public qvVerifier;
+    mapping(bytes32 => bool) public ballotSeen;
 
     bytes32 private constant BALLOT_TYPEHASH = keccak256("Ballot(bytes32 ballotHash)");
 
@@ -41,6 +42,9 @@ contract QVManager is EIP712 {
             qvVerifier.verifyProof(a, b, c, pubSignals),
             "invalid voice credit proof"
         );
+        bytes32 h = keccak256(encryptedBallot);
+        require(!ballotSeen[h], "duplicate ballot");
+        ballotSeen[h] = true;
         maci.publishMessage(encryptedBallot);
         emit BallotSubmitted(msg.sender, encryptedBallot);
     }
@@ -63,6 +67,9 @@ contract QVManager is EIP712 {
         );
         address signer = ECDSA.recover(digest, signature);
         require(signer == msg.sender, "bad sig");
+        bytes32 h = keccak256(encryptedBallot);
+        require(!ballotSeen[h], "duplicate ballot");
+        ballotSeen[h] = true;
         maci.publishMessage(encryptedBallot);
         emit BallotSubmitted(msg.sender, encryptedBallot);
     }

--- a/contracts/WalletFactory.sol
+++ b/contracts/WalletFactory.sol
@@ -8,7 +8,7 @@ import "@account-abstraction/contracts/core/EntryPoint.sol";
 contract WalletFactory {
     EntryPoint public immutable entryPoint;
     Verifier public immutable verifier;
-    mapping(address => address) public walletOf;
+    mapping(address => address) public walletOf; // owner => wallet
 
     event WalletMinted(address indexed owner, address indexed wallet);
 
@@ -27,14 +27,14 @@ contract WalletFactory {
         uint256[7] calldata pubSignals,
         address owner
     ) external returns (address wallet) {
-        require(walletOf[msg.sender] == address(0), "Factory: already minted");
+        require(walletOf[owner] == address(0), "Factory: already minted");
         require(
             verifier.verifyProof(a, b, c, pubSignals),
             "Factory: invalid proof"
         );
         bytes32 salt = keccak256(abi.encodePacked(owner, msg.sender));
         wallet = address(new SmartWallet{salt: salt}(entryPoint, owner));
-        walletOf[msg.sender] = wallet;
+        walletOf[owner] = wallet;
         emit WalletMinted(owner, wallet);
     }
 }

--- a/test/FuzzAndInvariant.t.sol
+++ b/test/FuzzAndInvariant.t.sol
@@ -41,7 +41,7 @@ contract FuzzTests is Test {
         vm.prank(caller);
         address wallet = factory.mintWallet(a, b, c, inputs, owner);
         assertTrue(wallet != address(0));
-        assertEq(factory.walletOf(caller), wallet);
+        assertEq(factory.walletOf(owner), wallet);
     }
 
     /// After a successful mint, a second mint must revert

--- a/test/WalletFactoryDeterminism.t.sol
+++ b/test/WalletFactoryDeterminism.t.sol
@@ -65,6 +65,6 @@ contract WalletFactoryDeterminismTest is Test {
         );
 
         assertEq(wallet, expected, "mintWallet wrong");
-        assertEq(factory.walletOf(alice), expected, "walletOf wrong");
+        assertEq(factory.walletOf(owner), expected, "walletOf wrong");
     }
 }


### PR DESCRIPTION
## Summary
- persist tally result in ElectionManagerV2
- prevent ballot replay in QVManager
- require unique wallets per owner in WalletFactory
- update unit tests
- update changelog

## Testing
- `forge test -q` *(fails: forge not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6841f0ac9f0c83279bd91a91bf79624f