### PR TITLE
Fix API base for frontend container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,7 @@ services:
       context: .
       dockerfile: Dockerfile.frontend
     environment:
+      NEXT_PUBLIC_API_BASE: http://backend:8000
       NEXT_PUBLIC_ENTRYPOINT: ${NEXT_PUBLIC_ENTRYPOINT:-0xYourEntryPointAddress}
       NEXT_PUBLIC_WALLET_FACTORY: ${NEXT_PUBLIC_WALLET_FACTORY:-0xYourFactoryAddress}
       NEXT_PUBLIC_ELECTION_MANAGER: ${NEXT_PUBLIC_ELECTION_MANAGER:-0x5FbDB2315678afecb367f032d93F642f64180aa3}

--- a/docs/handbook/README.md
+++ b/docs/handbook/README.md
@@ -21,6 +21,10 @@ configuration sets `EVM_RPC` along with `CELERY_BROKER` and
 `CELERY_BACKEND` so it can talk to the `anvil` and `redis` services. If you
 run the backend on its own, provide these variables manually.
 
+When running the frontend container, set `NEXT_PUBLIC_API_BASE` to
+`http://backend:8000` so the web UI can reach the API service within the
+Compose network.
+
 The frontend will be available on `http://localhost:3000`, the API on
 `http://localhost:8000` and Postgres on `localhost:5432`.
 


### PR DESCRIPTION
## Summary
- connect frontend container to backend using service name
- mention API base var in handbook docs

## Testing
- `yarn test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68427c786e00832797cd16db6d509e97