### PR TITLE
Handle missing wallet provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ packages/frontend/.next
 artifacts/
 !artifacts/
 !artifacts/manifest.json
+services/relay-daemon/dist

--- a/packages/frontend/src/lib/accountAbstraction.ts
+++ b/packages/frontend/src/lib/accountAbstraction.ts
@@ -7,9 +7,9 @@ const ELECTION_MANAGER_ADDR = process.env.NEXT_PUBLIC_ELECTION_MANAGER!;
 const BUNDLER_RPC_URL = process.env.NEXT_PUBLIC_BUNDLER_URL!;
 
 async function getAccountAPI(signer: ethers.Signer) {
-    const provider = new ethers.providers.Web3Provider((window as any).ethereum);
+    const provider = signer.provider ?? new ethers.providers.Web3Provider((window as any).ethereum);
     return new SimpleAccountAPI({
-        provider,
+        provider: provider as ethers.providers.Web3Provider,
         entryPointAddress: ENTRY_POINT_ADDRESS,
         owner: signer,
         factoryAddress: WALLET_FACTORY_ADDRESS,

--- a/packages/frontend/src/pages/mint.tsx
+++ b/packages/frontend/src/pages/mint.tsx
@@ -5,6 +5,10 @@ import { bundleCreateWallet } from "../lib/accountAbstraction";
 export default function MintPage() {
     const [txHash, setTxHash] = useState<string>();
     const onMint = async () => {
+        if (!(window as any).ethereum) {
+            alert('No Ethereum wallet detected');
+            return;
+        }
         const provider = new ethers.providers.Web3Provider((window as any).ethereum);
         await provider.send("eth_requestAccounts", []);
         const signer = provider.getSigner();

--- a/packages/frontend/src/pages/vote.tsx
+++ b/packages/frontend/src/pages/vote.tsx
@@ -21,6 +21,10 @@ function VotePage() {
     const id = router.query.id as string | undefined;
 
     const cast = async (option: 0 | 1) => {
+        if (!(window as any).ethereum) {
+            showToast({ type: 'error', message: 'No Ethereum wallet detected' });
+            return;
+        }
         const provider = new ethers.providers.Web3Provider((window as any).ethereum);
         await provider.send("eth_requestAccounts", []);
         const signer = provider.getSigner();

--- a/services/relay-daemon/index.ts
+++ b/services/relay-daemon/index.ts
@@ -24,7 +24,8 @@ const BRIDGE_SK = process.env.SOLANA_BRIDGE_SK as string;
 if (!ELECTION_MANAGER) throw new Error('ELECTION_MANAGER env var required');
 if (!BRIDGE_SK) throw new Error('SOLANA_BRIDGE_SK env var required');
 
-const ethProvider = new ethers.providers.JsonRpcProvider(EVM_RPC);
+const CHAIN_ID = Number(process.env.CHAIN_ID || '1337');
+const ethProvider = new ethers.providers.StaticJsonRpcProvider(EVM_RPC, { chainId: CHAIN_ID, name: 'local' });
 const iface = new ethers.utils.Interface(['event Tally(uint256,uint256)']);
 const pool = new Pool({ connectionString: POSTGRES_URL });
 


### PR DESCRIPTION
## Summary
- handle missing injected provider on voting & wallet mint pages
- infer provider from signer in account abstraction helper
- fix relay-daemon provider initialization
- ignore relay-daemon build output

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6842806c76148327bde5118ec94edf0b