### PR TITLE
Fix worker DB config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,7 @@ services:
     environment:
       CELERY_BROKER: redis://redis:6379/0
       CELERY_BACKEND: redis://redis:6379/0
-      DATABASE_URL: postgres://postgres:pass@db:5432/postgres
+      DATABASE_URL: postgresql://postgres:pass@db:5432/postgres
     depends_on:
       - redis
       - db

--- a/packages/backend/requirements.txt
+++ b/packages/backend/requirements.txt
@@ -10,4 +10,5 @@ redis
 grpcio
 grpcio-tools
 typer
+psycopg2-binary
 pytest


### PR DESCRIPTION
## Summary
- fix database connection URI for the Celery worker
- add Postgres driver dependency for backend

## Testing
- `pip install -q -r packages/backend/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684299f9e86c83279f841228eb6fafc6