### PR TITLE
Fix DB URL handling and anvil host

### DIFF
--- a/packages/backend/db.py
+++ b/packages/backend/db.py
@@ -11,8 +11,13 @@ from sqlalchemy.orm import sessionmaker
 import os
 
 SQLALCHEMY_DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./app.db")
+# SQLAlchemy expects the "postgresql" scheme; handle old "postgres" URLs too
+if SQLALCHEMY_DATABASE_URL.startswith("postgres://"):
+    SQLALCHEMY_DATABASE_URL = "postgresql://" + SQLALCHEMY_DATABASE_URL[len("postgres://"):]
+
 engine = create_engine(
-    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False} if SQLALCHEMY_DATABASE_URL.startswith("sqlite") else {}
+    SQLALCHEMY_DATABASE_URL,
+    connect_args={"check_same_thread": False} if SQLALCHEMY_DATABASE_URL.startswith("sqlite") else {},
 )
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 Base = declarative_base()

--- a/services/relay-daemon/index.ts
+++ b/services/relay-daemon/index.ts
@@ -13,7 +13,17 @@ import path from 'path';
 const idlPath = path.join(__dirname, '..', '..', '..', 'solana-programs', 'election', 'target', 'idl', 'election_mirror.json');
 const idl = JSON.parse(fs.readFileSync(idlPath, 'utf8'));
 
-const EVM_RPC = process.env.EVM_RPC || 'http://127.0.0.1:8545';
+let EVM_RPC = process.env.EVM_RPC || 'http://127.0.0.1:8545';
+// Allow running outside docker by translating the default 'anvil' hostname
+try {
+  const url = new URL(EVM_RPC);
+  if (url.hostname === 'anvil') {
+    url.hostname = '127.0.0.1';
+    EVM_RPC = url.toString();
+  }
+} catch {
+  // ignore malformed URL and use as-is
+}
 const SOLANA_RPC = process.env.SOLANA_RPC || 'http://localhost:8899';
 const POSTGRES_URL = process.env.POSTGRES_URL || 'postgres://postgres:pass@localhost:5432/postgres';
 const ELECTION_MANAGER = process.env.ELECTION_MANAGER as string;


### PR DESCRIPTION
## Summary
- handle legacy `postgres://` URLs in backend DB setup
- let relay daemon fall back to `127.0.0.1` when `EVM_RPC` uses the `anvil` host

## Testing
- `yarn test`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68429f33852c8327979395088e553c16