### PR TITLE
Handle string proofs in vote flow

### DIFF
--- a/packages/frontend/src/lib/accountAbstraction.ts
+++ b/packages/frontend/src/lib/accountAbstraction.ts
@@ -64,8 +64,19 @@ export async function bundleSubmitVote(
     const managerIface = new ethers.utils.Interface([
         "function enqueueMessage(uint256,uint256,bytes)"
     ]);
+
+    // The backend returns dummy proofs as strings like
+    // "proof-<hash>" which are not valid hex bytes. Convert any
+    // non-hex string proof to bytes so ethers can encode it.
+    const proofBytes =
+        typeof vcProof === "string" && !ethers.utils.isHexString(vcProof)
+            ? ethers.utils.toUtf8Bytes(vcProof)
+            : vcProof;
+
     const data = managerIface.encodeFunctionData("enqueueMessage", [
-        voteOption, nonce, vcProof,
+        voteOption,
+        nonce,
+        proofBytes,
     ]);
 
     const unsignedOp = await api.createSignedUserOp({


### PR DESCRIPTION
## Summary
- convert non-hex proof strings to bytes before encoding vote transactions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842a37f757c8327aa558a6ac2d729d6