### PR TITLE
Add env generation helper

### DIFF
--- a/docs/local_dev_cookbook.md
+++ b/docs/local_dev_cookbook.md
@@ -5,6 +5,14 @@
 ```bash
 git clone <repo>
 cd toting
+# Deploy contracts and write a local env file
+forge script script/DeployFactory.s.sol:DeployFactory \
+  --rpc-url http://localhost:8545 \
+  --private-key <key> --broadcast
+forge script script/DeployElectionManager.s.sol:DeployElectionManager \
+  --rpc-url http://localhost:8545 \
+  --private-key <key> --broadcast
+python3 scripts/export_frontend_env.py > packages/frontend/.env.local
 # Build images and start services
 docker-compose up -d
 # wait 60 s

--- a/scripts/export_frontend_env.py
+++ b/scripts/export_frontend_env.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+import json
+from pathlib import Path
+
+# load address from broadcast file
+
+def load_address(path):
+    file = Path(path) / 'run-latest.json'
+    if not file.exists():
+        raise SystemExit(f"missing {file}")
+    data = json.loads(file.read_text())
+    txs = data.get('transactions') or []
+    if not txs:
+        raise SystemExit(f"no transactions in {file}")
+    return txs[-1]['contractAddress']
+
+factory = load_address('broadcast/DeployFactory.s.sol/31337')
+manager = load_address('broadcast/DeployElectionManager.s.sol/31337')
+
+# zero address default for entrypoint
+entrypoint = '0x' + '0'*40
+print(f"NEXT_PUBLIC_ENTRYPOINT={entrypoint}")
+print(f"NEXT_PUBLIC_WALLET_FACTORY={factory}")
+print(f"NEXT_PUBLIC_ELECTION_MANAGER={manager}")
+print(f"ELECTION_MANAGER={manager}")


### PR DESCRIPTION
## Summary
- add `export_frontend_env.py` helper script
- document how to build local env

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_6842a868b7088327adbbfecd619743b4