### PR TITLE
Fix frontend vote call parameters

### DIFF
--- a/packages/frontend/src/lib/accountAbstraction.ts
+++ b/packages/frontend/src/lib/accountAbstraction.ts
@@ -55,6 +55,7 @@ export async function bundleCreateWallet(
 
 export async function bundleSubmitVote(
     signer: ethers.Signer,
+    electionId: number,
     voteOption: number,
     nonce: number,
     vcProof: Uint8Array | string
@@ -62,7 +63,7 @@ export async function bundleSubmitVote(
     const api = await getAccountAPI(signer);
 
     const managerIface = new ethers.utils.Interface([
-        "function enqueueMessage(uint256,uint256,bytes)"
+        "function enqueueMessage(uint256,uint256,uint256,bytes)"
     ]);
 
     // The backend returns dummy proofs as strings like
@@ -74,6 +75,7 @@ export async function bundleSubmitVote(
             : vcProof;
 
     const data = managerIface.encodeFunctionData("enqueueMessage", [
+        electionId,
         voteOption,
         nonce,
         proofBytes,

--- a/packages/frontend/src/pages/vote.tsx
+++ b/packages/frontend/src/pages/vote.tsx
@@ -74,7 +74,13 @@ function VotePage() {
         const vcProof = out.proof;
         const nonce = 1; // (the same nonce you passed above)
   
-        const userOpHash = await bundleSubmitVote(signer, /* option= */ out.pubSignals![0] /* or your stored option */, nonce, vcProof);
+        const userOpHash = await bundleSubmitVote(
+          signer,
+          Number(id!),
+          /* option= */ out.pubSignals![0] /* or your stored option */,
+          nonce,
+          vcProof
+        );
         setReceipt(userOpHash);
       } catch (err: any) {
         showToast({ type: 'error', message: err.message || 'proof error' });


### PR DESCRIPTION
## Summary
- pass election ID to `bundleSubmitVote`
- fix `enqueueMessage` interface to include election ID

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842ab9239ec83278fd775c18adbe42c