### PR TITLE
Fix websocket URL and show role banner

### DIFF
--- a/packages/frontend/src/components/NavBar.tsx
+++ b/packages/frontend/src/components/NavBar.tsx
@@ -53,6 +53,9 @@ export default function NavBar() {
       )}
       <ThemeToggle />
       <AuthChip />
+      {(role === 'admin' || role === 'verifier') && (
+        <div style={{background:'red',color:'white',textAlign:'center',padding:'0.25rem'}}>frontend-only role, not enforced</div>
+      )}
     </>
   );
 }

--- a/packages/frontend/src/components/ProgressOverlay.tsx
+++ b/packages/frontend/src/components/ProgressOverlay.tsx
@@ -6,13 +6,13 @@ export default function ProgressOverlay({ jobId, onDone }: { jobId: string; onDo
 
   useEffect(() => {
     // Build a proper ws:// or wss:// URL from whatever apiUrl() returns
-    const httpUrl = apiUrl(`/ws/proofs/${jobId}`);          // e.g. "http://localhost:8000/ws/proofs/…"
+    const httpUrl = apiUrl(`/ws/proofs/${jobId}`); // e.g. "http://backend:8000/ws/proofs/..."
     const urlObj = new URL(httpUrl);
     // switch protocol from 'http:' → 'ws:' (or 'https:' → 'wss:')
-    if (urlObj.protocol === 'https:') {
-      urlObj.protocol = 'wss:';
-    } else {
-      urlObj.protocol = 'ws:';
+    urlObj.protocol = urlObj.protocol === 'https:' ? 'wss:' : 'ws:';
+    // when API_BASE uses an internal hostname (e.g. "backend"), use browser host
+    if (urlObj.hostname !== window.location.hostname) {
+      urlObj.hostname = window.location.hostname;
     }
     const ws = new WebSocket(urlObj.toString());
 


### PR DESCRIPTION
## Summary
- use browser hostname when building websocket URL
- warn that admin/verifier roles are only client-side

## Testing
- `yarn --cwd packages/frontend test`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_6842dba4514c8327b0d4d0bdc233f94f