### PR TITLE
Lock foundry image and trim Docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -27,3 +27,7 @@ proofs
 # Solana build output
 solana-programs/**/target
 !solana-programs/election/target/idl
+
+# Large source directories not needed for orchestrator image
+contracts
+circuits

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
     needs: build
     services:
       anvil:
-        image: ghcr.io/foundry-rs/foundry:latest
+        image: ghcr.io/foundry-rs/foundry:1.0.0
         options: >-
           --health-cmd "anvil --version" --health-interval 10s --health-timeout 5s --health-retries 5
         ports:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       anvil:
-        image: ghcr.io/foundry-rs/foundry:latest
+        image: ghcr.io/foundry-rs/foundry:1.0.0
         options: >-
           --health-cmd "anvil --version" --health-interval 10s --health-timeout 5s --health-retries 5
         ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   # Anvil (Foundry local blockchain)
   # ----------------------------------------
   anvil:
-    image: ghcr.io/foundry-rs/foundry:latest
+    image: ghcr.io/foundry-rs/foundry:1.0.0
     user: "0"
     # CHANGE: Switched from a list to a multi-line string for the command.
     # This is more robust and avoids parsing issues.
@@ -101,7 +101,7 @@ services:
 
   orchestrator:
     build:
-      context: .
+      context: services/orchestrator
       dockerfile: Dockerfile
     environment:
       EVM_RPC: http://anvil:8545

--- a/services/orchestrator/Dockerfile
+++ b/services/orchestrator/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.11-slim
+RUN apt-get update && apt-get install -y curl gnupg \
+    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY . /app/orchestrator
+RUN pip install web3 requests && npm install -g snarkjs
+CMD ["python", "/app/orchestrator/main.py"]


### PR DESCRIPTION
## Summary
- pin `ghcr.io/foundry-rs/foundry` image to `1.0.0`
- shrink orchestrator build context by using a Dockerfile inside `services/orchestrator`
- ignore heavy circuit and contract directories in `.dockerignore`
- update CI and e2e workflows to use the pinned image

## Testing
- `pytest packages/backend/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_6842db9d955083279aab4600f9e25a1e