### PR TITLE
Switch auth tokens to sessionStorage

### DIFF
--- a/docs/uiux_pbis.md
+++ b/docs/uiux_pbis.md
@@ -14,7 +14,7 @@ The following product backlog items (PBIs) capture upcoming UI and UX work.
 | **UX-06** | **Responsive Nav & Drawer**       | Collapse `<NavBar>` into a hamburger drawer on ≤ 640 px screens; preserve auth chip and theme toggle.                                                             |
 | **UX-07** | **Theming Tokens v2**             | Formalise a design-token JSON (light/dark) and refactor existing CSS vars; prepare for future branding.                                                           |
 | **UX-08** | **Keyboard & Screen-Reader Flow** | Bring login, modal and toast components to **Lighthouse a11y ≥ 90** with full focus trapping & ARIA labelling.                                                    |
-| **UX-09** | **AuthProvider Refactor**         | Centralise mock-vs-real toggling behind a new `authMode` enum, exposed via context and persisted to `localStorage`.                                               |
+| **UX-09** | **AuthProvider Refactor**         | Centralise mock-vs-real toggling behind a new `authMode` enum, exposed via context and persisted to `sessionStorage`.                                               |
 | **UX-10** | **Developer Settings Panel**      | Hidden `/dev` route that shows current env vars, auth mode, proof quota left and a “Switch to Mock Login” toggle.                                                 |
 | **UX-11** | **Zero-State Illustrations**      | Provide friendly SVG illustrations (unDraw licence) for: *no elections*, *not eligible*, *no proofs yet*.                                                         |
 | **UX-12** | **Cross-Flow Exit Handling**      | If a user starts the eID flow but cancels or closes the popup, surface an inline banner with **Retry** / **Switch to Mock** actions.                              |
@@ -40,7 +40,7 @@ The following product backlog items (PBIs) capture upcoming UI and UX work.
 * **Design**: Two equal buttons (primary = eID, secondary = Mock) with descriptive sub-text.
 * **Behaviour**
   * Clicking **eID** behaves exactly as today.
-  * Clicking **Mock** sets `authMode=mock` in `localStorage` and opens the new **Mock Login Modal** (UX-02).
+  * Clicking **Mock** sets `authMode=mock` in `sessionStorage` and opens the new **Mock Login Modal** (UX-02).
 * **Analytics**: emit `auth_mode_selected` event with `{ mode }`.
 * **Dependencies**: None explicit – first item to implement.
 

--- a/packages/frontend/__tests__/account.menu.test.js
+++ b/packages/frontend/__tests__/account.menu.test.js
@@ -14,14 +14,14 @@ function makeToken(role) {
 
 describe('account menu role switcher', () => {
   beforeEach(() => {
-    localStorage.clear();
+    sessionStorage.clear();
     router.setCurrentUrl('/');
   });
 
   test('admin sees role switch option', () => {
-    localStorage.setItem('id_token', makeToken('admin'));
-    localStorage.setItem('eligibility', 'true');
-    localStorage.setItem('auth_mode', 'eid');
+    sessionStorage.setItem('id_token', makeToken('admin'));
+    sessionStorage.setItem('eligibility', 'true');
+    sessionStorage.setItem('auth_mode', 'eid');
     const { getByLabelText, getByText } = render(
       <I18nProvider>
         <AuthProvider>
@@ -34,9 +34,9 @@ describe('account menu role switcher', () => {
   });
 
   test('user does not see role switch option', () => {
-    localStorage.setItem('id_token', makeToken('user'));
-    localStorage.setItem('eligibility', 'true');
-    localStorage.setItem('auth_mode', 'eid');
+    sessionStorage.setItem('id_token', makeToken('user'));
+    sessionStorage.setItem('eligibility', 'true');
+    sessionStorage.setItem('auth_mode', 'eid');
     const { getByLabelText, queryByText } = render(
       <I18nProvider>
         <AuthProvider>

--- a/packages/frontend/__tests__/authprovider.message.test.js
+++ b/packages/frontend/__tests__/authprovider.message.test.js
@@ -13,7 +13,7 @@ function Dummy() {
 
 describe('postMessage login', () => {
   beforeEach(() => {
-    localStorage.clear();
+    sessionStorage.clear();
     router.setCurrentUrl('/');
   });
 
@@ -30,8 +30,8 @@ describe('postMessage login', () => {
     await act(async () => {
       window.dispatchEvent(evt);
     });
-    await waitFor(() => expect(localStorage.getItem('id_token')).toBe('jwt'));
-    expect(localStorage.getItem('auth_mode')).toBe('eid');
+    await waitFor(() => expect(sessionStorage.getItem('id_token')).toBe('jwt'));
+    expect(sessionStorage.getItem('auth_mode')).toBe('eid');
     expect(router.asPath).toBe('/dashboard');
   });
 });

--- a/packages/frontend/__tests__/role.guard.test.js
+++ b/packages/frontend/__tests__/role.guard.test.js
@@ -14,14 +14,14 @@ function makeToken(role) {
 
 describe('role based guards', () => {
   beforeEach(() => {
-    localStorage.clear();
+    sessionStorage.clear();
     router.setCurrentUrl('/');
   });
 
   test('admin sees create link', () => {
-    localStorage.setItem('id_token', makeToken('admin'));
-    localStorage.setItem('eligibility', 'true');
-    localStorage.setItem('auth_mode', 'eid');
+    sessionStorage.setItem('id_token', makeToken('admin'));
+    sessionStorage.setItem('eligibility', 'true');
+    sessionStorage.setItem('auth_mode', 'eid');
     const { getByText } = render(
       <AuthProvider>
         <NavBar />
@@ -31,9 +31,9 @@ describe('role based guards', () => {
   });
 
   test('verifier sees panel link', () => {
-    localStorage.setItem('id_token', makeToken('verifier'));
-    localStorage.setItem('eligibility', 'true');
-    localStorage.setItem('auth_mode', 'eid');
+    sessionStorage.setItem('id_token', makeToken('verifier'));
+    sessionStorage.setItem('eligibility', 'true');
+    sessionStorage.setItem('auth_mode', 'eid');
     const { getByText } = render(
       <AuthProvider>
         <NavBar />
@@ -43,9 +43,9 @@ describe('role based guards', () => {
   });
 
   test('admin does not see panel link', () => {
-    localStorage.setItem('id_token', makeToken('admin'));
-    localStorage.setItem('eligibility', 'true');
-    localStorage.setItem('auth_mode', 'eid');
+    sessionStorage.setItem('id_token', makeToken('admin'));
+    sessionStorage.setItem('eligibility', 'true');
+    sessionStorage.setItem('auth_mode', 'eid');
     const { queryByText } = render(
       <AuthProvider>
         <NavBar />
@@ -55,9 +55,9 @@ describe('role based guards', () => {
   });
 
   test('user does not see create link', () => {
-    localStorage.setItem('id_token', makeToken('user'));
-    localStorage.setItem('eligibility', 'true');
-    localStorage.setItem('auth_mode', 'eid');
+    sessionStorage.setItem('id_token', makeToken('user'));
+    sessionStorage.setItem('eligibility', 'true');
+    sessionStorage.setItem('auth_mode', 'eid');
     const { queryByText } = render(
       <AuthProvider>
         <NavBar />
@@ -67,9 +67,9 @@ describe('role based guards', () => {
   });
 
   test('forbidden route shows 403', () => {
-    localStorage.setItem('id_token', makeToken('user'));
-    localStorage.setItem('eligibility', 'true');
-    localStorage.setItem('auth_mode', 'eid');
+    sessionStorage.setItem('id_token', makeToken('user'));
+    sessionStorage.setItem('eligibility', 'true');
+    sessionStorage.setItem('auth_mode', 'eid');
     const Protected = withAuth(() => <p>secret</p>, ['verifier']);
     const { getByText } = render(
       <AuthProvider>

--- a/packages/frontend/src/lib/AuthProvider.tsx
+++ b/packages/frontend/src/lib/AuthProvider.tsx
@@ -56,24 +56,24 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const router = useRouter();
 
   useEffect(() => {
-    const stored = localStorage.getItem('id_token');
-    const storedMode = (localStorage.getItem('auth_mode') as AuthMode) || 'guest';
+    const stored = sessionStorage.getItem('id_token');
+    const storedMode = (sessionStorage.getItem('auth_mode') as AuthMode) || 'guest';
     setMode(storedMode);
     if (stored && !tokenExpired(stored)) {
       setToken(stored);
-      setEligibility(localStorage.getItem('eligibility') === 'true');
+      setEligibility(sessionStorage.getItem('eligibility') === 'true');
       const p = decodePayload(stored);
       setRole(p?.role === 'admin' || p?.role === 'verifier' ? p.role : 'user');
     } else {
-      localStorage.removeItem('id_token');
-      localStorage.removeItem('eligibility');
+      sessionStorage.removeItem('id_token');
+      sessionStorage.removeItem('eligibility');
     }
 
     const handler = (e: MessageEvent) => {
       if (e.origin !== 'http://localhost:3000') return;
       const { id_token, eligibility: elig } = e.data || {};
       if (typeof id_token === 'string' && typeof elig === 'boolean') {
-        const m = (localStorage.getItem('auth_mode') as AuthMode) || 'eid';
+        const m = (sessionStorage.getItem('auth_mode') as AuthMode) || 'eid';
         login(id_token, elig, m);
         router.replace('/dashboard');
       }
@@ -89,9 +89,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setMode(m);
     const p = decodePayload(tok);
     setRole(p?.role === 'admin' || p?.role === 'verifier' ? p.role : 'user');
-    localStorage.setItem('id_token', tok);
-    localStorage.setItem('eligibility', String(elig));
-    localStorage.setItem('auth_mode', m);
+    sessionStorage.setItem('id_token', tok);
+    sessionStorage.setItem('eligibility', String(elig));
+    sessionStorage.setItem('auth_mode', m);
   };
 
   const logout = () => {
@@ -99,9 +99,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setEligibility(false);
     setMode('guest');
     setRole('user');
-    localStorage.removeItem('id_token');
-    localStorage.removeItem('eligibility');
-    localStorage.removeItem('auth_mode');
+    sessionStorage.removeItem('id_token');
+    sessionStorage.removeItem('eligibility');
+    sessionStorage.removeItem('auth_mode');
     router.replace('/');
   };
 


### PR DESCRIPTION
## Summary
- store JWT and eligibility in sessionStorage instead of localStorage
- update tests for sessionStorage
- note sessionStorage in UI/UX PBIs docs

## Testing
- `npm install` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68431aae89408327a737b09d45ba5dd2