### PR TITLE
Add coverage lcov and secret masking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,7 +171,7 @@ jobs:
           submodules: recursive
       - uses: foundry-rs/foundry-toolchain@v1
       - name: Run forge coverage
-        run: forge coverage --report lcov > coverage.lcov
+        run: forge coverage --lcov > coverage.lcov
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,7 @@
 - Persist tally results on-chain in `ElectionManagerV2`.
 - Replay protection for ballots in `QVManager`.
 - `WalletFactory` restricts one wallet per owner.
+
+## [0.1.0] - 2025-06-06
+### Added
+- Initial preview release tagged for dogfooding.

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUTPUT=".env.deployed"
+: > "$OUTPUT"
+
+KEY="${ORCHESTRATOR_KEY:-${PRIVATE_KEY:-}}"
+if [[ -z "$KEY" ]]; then
+  echo "Missing ORCHESTRATOR_KEY/PRIVATE_KEY" >&2
+  exit 1
+fi
+
+# Mask the secret in GitHub Actions logs if present
+printf "::add-mask::%s\n" "$KEY" || true
+
+echo "ORCHESTRATOR_KEY=$KEY" >> "$OUTPUT"
+echo "written $OUTPUT"


### PR DESCRIPTION
## Summary
- generate preview release notes
- add scripts/setup_env.sh for writing a private key to `.env.deployed` while masking in CI logs
- update CI to use `forge coverage --lcov`

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_68431ab4d72c8327bb9dde056d5b00db