### PR TITLE
Optimize election storage

### DIFF
--- a/contracts/ElectionManager.sol
+++ b/contracts/ElectionManager.sol
@@ -12,12 +12,12 @@ contract ElectionManager {
     TallyVerifier public tallyVerifier;
     bool public tallied;
 
-    event ElectionCreated(uint id, bytes32 meta);
+    event ElectionCreated(uint id, bytes32 indexed meta);
     event Tally(uint256 A, uint256 B);
 
     struct E {
-        uint start;
-        uint end;
+        uint128 start;
+        uint128 end;
     }
     mapping(uint => E) public elections;
     uint public nextId;
@@ -37,9 +37,14 @@ contract ElectionManager {
     }
 
     function createElection(bytes32 meta) external {
-        elections[nextId] = E(block.number, block.number + 7200);
+        elections[nextId] = E(
+            uint128(block.number),
+            uint128(block.number + 7200)
+        );
         emit ElectionCreated(nextId, meta);
-        nextId++;
+        unchecked {
+            nextId++;
+        }
     }
 
     function enqueueMessage(

--- a/contracts/ElectionManagerV2.sol
+++ b/contracts/ElectionManagerV2.sol
@@ -18,8 +18,8 @@ contract ElectionManagerV2 is Initializable, UUPSUpgradeable, OwnableUpgradeable
     bool public tallied; // slot from V1
 
     struct Election {
-        uint256 start;
-        uint256 end;
+        uint128 start;
+        uint128 end;
     }
 
     mapping(uint256 => Election) public elections;
@@ -43,9 +43,14 @@ contract ElectionManagerV2 is Initializable, UUPSUpgradeable, OwnableUpgradeable
     }
 
     function createElection(bytes32 meta) external onlyOwner {
-        elections[nextId] = Election(block.number, block.number + 7200);
+        elections[nextId] = Election(
+            uint128(block.number),
+            uint128(block.number + 7200)
+        );
         emit ElectionCreated(nextId, meta);
-        nextId++;
+        unchecked {
+            nextId++;
+        }
     }
 
     function enqueueMessage(
@@ -74,7 +79,7 @@ contract ElectionManagerV2 is Initializable, UUPSUpgradeable, OwnableUpgradeable
         tallied = true;
     }
 
-    event ElectionCreated(uint256 id, bytes32 meta);
+    event ElectionCreated(uint256 id, bytes32 indexed meta);
     event Tally(uint256 A, uint256 B);
 
     function upgradeTo(address newImplementation)

--- a/test/FuzzAndInvariant.t.sol
+++ b/test/FuzzAndInvariant.t.sol
@@ -76,11 +76,11 @@ contract FuzzTests is Test {
     function testFuzz_RandomWindow(uint64 startOffset, uint64 duration) public {
         vm.assume(startOffset < 1000 && duration > 0 && duration < 1000);
         em.createElection(bytes32(uint256(0x42)));
-        bytes32 base = keccak256(abi.encode(uint256(0), uint256(2)));
-        uint start = block.number + startOffset;
-        uint end = start + duration;
-        vm.store(address(em), base, bytes32(start));
-        vm.store(address(em), bytes32(uint256(base) + 1), bytes32(end));
+        bytes32 base = keccak256(abi.encode(uint256(0), uint256(1)));
+        uint256 start = block.number + startOffset;
+        uint256 end = start + duration;
+        bytes32 packed = bytes32((uint256(end) << 128) | uint256(start));
+        vm.store(address(em), base, packed);
 
         vm.expectRevert("closed");
         em.enqueueMessage(0, 1, 0, new bytes(0));


### PR DESCRIPTION
## Summary
- pack election struct with uint128s
- index meta in `ElectionCreated` event
- increment `nextId` in unchecked block
- update fuzz test for new layout

## Testing
- `npm test`
- `forge test` *(fails: EvmError: Revert)*

------
https://chatgpt.com/codex/tasks/task_e_68431a90298c8327acede8cffe708427