### PR TITLE
Fix doc instructions on restarting frontend

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 * text eol=lf
 packages/backend/__pycache__/main.cpython-310.pyc -text
+packages/backend/__pycache__/*.pyc -text
 packages/frontend/.next/** -text

--- a/docs/local_dev_cookbook.md
+++ b/docs/local_dev_cookbook.md
@@ -39,6 +39,12 @@ This guide provides setup instructions for a standard Windows environment using 
     docker-compose up -d
     ```
 
+    *Whenever you rerun `scripts/setup_env.sh` to redeploy the contracts, you must
+    restart the frontend container so it reads the updated `.env` values.*
+    ```powershell
+    docker-compose restart frontend
+    ```
+
 6.  **Access the App**:
     The frontend will be available at `http://localhost:3000`.
 


### PR DESCRIPTION
## Summary
- clarify that the frontend must be restarted after running `setup_env.sh`
- mark pyc cache files as binary so git doesn't attempt line-ending conversions

## Testing
- `npm test` *(fails: Property 'address' does not exist on type 'IdlMetadata')*

------
https://chatgpt.com/codex/tasks/task_e_6847f711281883279967e42f0fae1df9