### PR TITLE
Improve factory address checks

### DIFF
--- a/docs/local_dev_cookbook.md
+++ b/docs/local_dev_cookbook.md
@@ -82,3 +82,18 @@ Follow these steps to perform a hard reset:
 If the problem still persists, run this diagnostic command to see what the container's file system looks like. The `lib` directory should not be empty.
 ```powershell
 docker-compose exec anvil ls -lR /app/lib
+```
+
+### "Factory not deployed" errors
+
+If you see an error like:
+```
+Factory not deployed at 0x.... Did you run setup_env.sh and restart your dev server?
+```
+
+it usually means the contracts were redeployed but the frontend is still using old addresses cached from a previous run. Run the setup script again and then restart the frontend so it picks up the new `.env.local` values:
+```powershell
+docker-compose exec anvil /app/scripts/setup_env.sh
+docker-compose restart frontend
+```
+

--- a/packages/frontend/src/lib/ProofWalletAPI.ts
+++ b/packages/frontend/src/lib/ProofWalletAPI.ts
@@ -57,7 +57,12 @@ export class ProofWalletAPI extends SimpleAccountAPI {
     if (!this.factoryAddress) {
         throw new Error("Factory address is not defined");
     }
-    
+
+    const codeAtFactory = await this.provider.getCode(this.factoryAddress);
+    if (codeAtFactory === '0x') {
+        throw new Error(`Factory not deployed at ${this.factoryAddress}. Did you run setup_env.sh and restart your dev server?`);
+    }
+
     const factory = new ethers.Contract(this.factoryAddress, FACTORY_ABI, this.provider);
     const ownerAddress = await this.owner.getAddress();
     


### PR DESCRIPTION
## Summary
- warn when the wallet factory address has no code
- add troubleshooting note for stale frontend addresses

## Testing
- `npm test --prefix packages/frontend` *(fails: jest not found)*
- `npm run type-check --prefix packages/frontend` *(fails to compile)*

------
https://chatgpt.com/codex/tasks/task_e_684801bea5648327a95b881c7fed1302