### PR TITLE
Improve troubleshooting for factory deployment errors

### DIFF
--- a/docs/local_dev_cookbook.md
+++ b/docs/local_dev_cookbook.md
@@ -97,3 +97,9 @@ docker-compose exec anvil /app/scripts/setup_env.sh
 docker-compose restart frontend
 ```
 
+If you **still** see the error, make sure your wallet (e.g. MetaMask) is
+connected to the local Anvil network. The setup script starts Anvil with chain
+ID `31337`. If your wallet is pointed at a different chain (such as `1337`),
+the frontend will query the wrong network and the factory contract will appear
+missing.
+

--- a/packages/frontend/src/lib/ProofWalletAPI.ts
+++ b/packages/frontend/src/lib/ProofWalletAPI.ts
@@ -60,7 +60,12 @@ export class ProofWalletAPI extends SimpleAccountAPI {
 
     const codeAtFactory = await this.provider.getCode(this.factoryAddress);
     if (codeAtFactory === '0x') {
-        throw new Error(`Factory not deployed at ${this.factoryAddress}. Did you run setup_env.sh and restart your dev server?`);
+        const network = await this.provider.getNetwork();
+        throw new Error(
+            `Factory not deployed at ${this.factoryAddress} on chain ${network.chainId}. ` +
+            `Did you run setup_env.sh and restart your dev server? ` +
+            `Check that your wallet is connected to the local Anvil network.`
+        );
     }
 
     const factory = new ethers.Contract(this.factoryAddress, FACTORY_ABI, this.provider);


### PR DESCRIPTION
## Summary
- enhance error message in `ProofWalletAPI` with chain ID details
- document how a wrong wallet network leads to the "Factory not deployed" error

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684815ba644c8327aed2b463796ccf8b