### PR TITLE
Add admin dashboard UI

### DIFF
--- a/packages/frontend/src/components/AdminElectionForm.tsx
+++ b/packages/frontend/src/components/AdminElectionForm.tsx
@@ -1,0 +1,62 @@
+import { useState } from 'react';
+import { useAuth } from '../lib/AuthProvider';
+import { useToast } from '../lib/ToastProvider';
+import { useSWRConfig } from 'swr';
+import { apiUrl } from '../lib/api';
+
+export interface Election {
+  id: number;
+  status: string;
+  tally?: string;
+}
+
+export default function AdminElectionForm({ onCreated }: { onCreated?: (e: Election) => void }) {
+  const { token } = useAuth();
+  const { showToast } = useToast();
+  const { mutate } = useSWRConfig();
+  const [meta, setMeta] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const submit = async () => {
+    setLoading(true);
+    try {
+      JSON.parse(meta);
+    } catch {
+      showToast({ type: 'error', message: 'Invalid JSON' });
+      setLoading(false);
+      return;
+    }
+    const res = await fetch(apiUrl('/elections'), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ metadata: meta }),
+    });
+    if (res.ok) {
+      const data: Election = await res.json();
+      mutate(['/elections', token]);
+      onCreated?.(data);
+    } else {
+      showToast({ type: 'error', message: 'Failed to create election' });
+    }
+    setLoading(false);
+  };
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+      <label htmlFor="meta">Election Metadata (JSON)</label>
+      <textarea
+        id="meta"
+        value={meta}
+        onChange={(e) => setMeta(e.target.value)}
+        rows={10}
+        style={{ fontFamily: 'monospace', border: '1px solid #ccc', padding: '0.5rem' }}
+      />
+      <button onClick={submit} disabled={loading || !meta.trim()}>
+        {loading ? 'Submitting...' : 'Create'}
+      </button>
+    </div>
+  );
+}

--- a/packages/frontend/src/components/AdminElectionList.tsx
+++ b/packages/frontend/src/components/AdminElectionList.tsx
@@ -1,0 +1,34 @@
+import Link from 'next/link';
+import { NoElections } from './ZeroState';
+
+export interface AdminElection {
+  id: number;
+  status: string;
+  tally?: string;
+}
+
+export default function AdminElectionList({ elections }: { elections: AdminElection[] }) {
+  if (!elections.length) return <NoElections />;
+  return (
+    <table>
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Status</th>
+          <th>Tally</th>
+        </tr>
+      </thead>
+      <tbody>
+        {elections.map((e) => (
+          <tr key={e.id}>
+            <td>
+              <Link href={`/admin/elections/${e.id}`}>{e.id}</Link>
+            </td>
+            <td>{e.status}</td>
+            <td>{e.tally || '-'}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/packages/frontend/src/components/AdminStatusForm.tsx
+++ b/packages/frontend/src/components/AdminStatusForm.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react';
+import { useAuth } from '../lib/AuthProvider';
+import { apiUrl } from '../lib/api';
+
+export default function AdminStatusForm({ id, current, onUpdated }: { id: number; current: string; onUpdated: () => void }) {
+  const { token } = useAuth();
+  const [status, setStatus] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const submit = async () => {
+    if (!status) return;
+    setLoading(true);
+    await fetch(apiUrl(`/elections/${id}`), {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ status }),
+    });
+    setStatus('');
+    setLoading(false);
+    onUpdated();
+  };
+
+  return (
+    <div style={{ marginTop: '1rem' }}>
+      <label>
+        Status:
+        <select value={status} onChange={(e) => setStatus(e.target.value)}>
+          <option value="">--</option>
+          <option value="pending">pending</option>
+          <option value="open">open</option>
+          <option value="closed">closed</option>
+          <option value="tallied">tallied</option>
+        </select>
+      </label>
+      <button onClick={submit} disabled={loading || !status} style={{ marginLeft: '0.5rem' }}>
+        {loading ? 'Updating...' : 'Update'}
+      </button>
+    </div>
+  );
+}

--- a/packages/frontend/src/components/NavBar.tsx
+++ b/packages/frontend/src/components/NavBar.tsx
@@ -19,6 +19,7 @@ export default function NavBar() {
           {(role === 'admin' || role === 'verifier') && (
             <Link href="/elections/create">Create Election</Link>
           )}
+          {role === 'admin' && <Link href="/admin">Admin</Link>}
           {role === 'verifier' && <Link href="/verifier">Verifier Panel</Link>}
         </>
       )}

--- a/packages/frontend/src/pages/admin/elections/[id].tsx
+++ b/packages/frontend/src/pages/admin/elections/[id].tsx
@@ -1,0 +1,44 @@
+import { useRouter } from 'next/router';
+import useSWR from 'swr';
+import NavBar from '../../../components/NavBar';
+import withAuth from '../../../components/withAuth';
+import { useAuth } from '../../../lib/AuthProvider';
+import { jsonFetcher } from '../../../lib/api';
+import AdminStatusForm from '../../../components/AdminStatusForm';
+
+interface Election {
+  id: number;
+  status: string;
+  tally?: string;
+}
+
+const fetcher = ([url, token]: [string, string]) => jsonFetcher([url, token]);
+
+function AdminElectionDetail() {
+  const router = useRouter();
+  const { token } = useAuth();
+  const { id } = router.query;
+  const { data, error, mutate } = useSWR<Election>(id && token ? [`/elections/${id}`, token] as [string, string] : null, fetcher);
+
+  if (error) return <><NavBar /><p style={{ color: 'red' }}>Error loading</p></>;
+
+  return (
+    <>
+      <NavBar />
+      <div style={{ padding: '1rem' }}>
+        {!data ? (
+          <p>Loading...</p>
+        ) : (
+          <div>
+            <h2>Election {data.id}</h2>
+            <p>Status: {data.status}</p>
+            {data.tally && <p>Tally: {data.tally}</p>}
+            <AdminStatusForm id={data.id} current={data.status} onUpdated={mutate} />
+          </div>
+        )}
+      </div>
+    </>
+  );
+}
+
+export default withAuth(AdminElectionDetail, ['admin']);

--- a/packages/frontend/src/pages/admin/elections/create.tsx
+++ b/packages/frontend/src/pages/admin/elections/create.tsx
@@ -1,0 +1,23 @@
+import { useRouter } from 'next/router';
+import NavBar from '../../../components/NavBar';
+import withAuth from '../../../components/withAuth';
+import AdminElectionForm, { Election } from '../../../components/AdminElectionForm';
+
+function CreateElectionPage() {
+  const router = useRouter();
+  const onCreated = (e: Election) => {
+    router.push(`/admin/elections/${e.id}`);
+  };
+
+  return (
+    <>
+      <NavBar />
+      <div style={{ padding: '1rem', maxWidth: '800px', margin: 'auto' }}>
+        <h2>Create Election</h2>
+        <AdminElectionForm onCreated={onCreated} />
+      </div>
+    </>
+  );
+}
+
+export default withAuth(CreateElectionPage, ['admin']);

--- a/packages/frontend/src/pages/admin/index.tsx
+++ b/packages/frontend/src/pages/admin/index.tsx
@@ -1,0 +1,30 @@
+import useSWR from 'swr';
+import NavBar from '../../components/NavBar';
+import withAuth from '../../components/withAuth';
+import { useAuth } from '../../lib/AuthProvider';
+import { jsonFetcher } from '../../lib/api';
+import AdminElectionList, { AdminElection } from '../../components/AdminElectionList';
+
+const fetcher = ([url, token]: [string, string]) => jsonFetcher([url, token]);
+
+function AdminDashboard() {
+  const { token, logout } = useAuth();
+  const { data, error } = useSWR<AdminElection[]>(token ? ['/elections', token] as [string, string] : null, fetcher);
+
+  if (error) {
+    if (error.message === 'Unauthorized') logout();
+    return <p style={{ color: 'red' }}>Failed to load elections</p>;
+  }
+
+  return (
+    <>
+      <NavBar />
+      <div style={{ padding: '1rem' }}>
+        <h2>Admin Dashboard</h2>
+        {!data ? <p>Loading...</p> : <AdminElectionList elections={data} />}
+      </div>
+    </>
+  );
+}
+
+export default withAuth(AdminDashboard, ['admin']);


### PR DESCRIPTION
## Summary
- provide /admin dashboard listing elections
- allow admins to create elections via new form
- allow status updates for each election
- surface Admin link in NavBar

## Testing
- `yarn test` *(fails: jest not found)*
- `yarn test` in repo root


------
https://chatgpt.com/codex/tasks/task_e_684829bbf270832792102e9c1835a36c