### PR TITLE
Add basic invariants for manager upgrade and wallet mint

### DIFF
--- a/test/AuditInvariant.t.sol
+++ b/test/AuditInvariant.t.sol
@@ -3,28 +3,75 @@
 pragma solidity ^0.8.24;
 
 import "forge-std/Test.sol";
+import {EntryPoint} from "@account-abstraction/contracts/core/EntryPoint.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 import {ElectionManagerV2} from "../contracts/ElectionManagerV2.sol";
 import {WalletFactory} from "../contracts/WalletFactory.sol";
+import {Verifier} from "../contracts/Verifier.sol";
+import {MockMACI} from "../contracts/MockMACI.sol";
+import {IMACI} from "../contracts/interfaces/IMACI.sol";
+
+contract TestVerifier is Verifier {
+    function verifyProof(uint256[2] calldata, uint256[2][2] calldata, uint256[2] calldata, uint256[7] calldata)
+        public
+        view
+        override
+        returns (bool)
+    {
+        return true;
+    }
+}
 
 /// @notice Placeholder invariants expanded during the audit hardening phase
 contract AuditInvariant is Test {
-    ElectionManagerV2 manager;
-    WalletFactory factory;
+    ElectionManagerV2 public manager;
+    WalletFactory public factory;
+    EntryPoint public entryPoint;
+    TestVerifier public verifier;
+
+    address internal owner;
+    address internal attacker;
+    address internal walletOwner;
 
     function setUp() public {
-        // TODO: deploy contracts for invariant tests
+        owner = address(this);
+        attacker = vm.addr(1);
+        walletOwner = vm.addr(2);
+
+        entryPoint = new EntryPoint();
+        verifier = new TestVerifier();
+        factory = new WalletFactory(entryPoint, verifier);
+
+        ElectionManagerV2 implementation = new ElectionManagerV2();
+        MockMACI maci = new MockMACI();
+        bytes memory data = abi.encodeCall(ElectionManagerV2.initialize, (IMACI(address(maci)), owner));
+        ERC1967Proxy proxy = new ERC1967Proxy(address(implementation), data);
+        manager = ElectionManagerV2(address(proxy));
     }
 
     /// @dev Only the contract owner should be able to upgrade the manager
-    /// TODO: rename to `invariant_onlyOwnerCanUpgrade` once implemented
-    function todo_onlyOwnerCanUpgrade() public {
-        // TODO: implement property test
+    function invariant_onlyOwnerCanUpgrade() public {
+        ElectionManagerV2 newImpl = new ElectionManagerV2();
+
+        vm.prank(attacker);
+        vm.expectRevert("Ownable: caller is not the owner");
+        manager.upgradeTo(address(newImpl));
     }
 
     /// @dev A single wallet should be minted per EOA
-    /// TODO: rename to `invariant_uniqueWalletMint` once implemented
-    function todo_uniqueWalletMint() public {
-        // TODO: implement property test
+    function invariant_uniqueWalletMint() public {
+        uint256[2] memory a;
+        uint256[2][2] memory b;
+        uint256[2] memory c;
+        uint256[7] memory inputs;
+        uint256 salt = 0;
+
+        if (factory.walletOf(walletOwner) == address(0)) {
+            factory.mintWallet(a, b, c, inputs, walletOwner, salt);
+        }
+
+        vm.expectRevert("Factory: already minted");
+        factory.mintWallet(a, b, c, inputs, walletOwner, salt);
     }
 }


### PR DESCRIPTION
## Summary
- deploy ElectionManagerV2 and WalletFactory in `AuditInvariant` tests
- implement invariants checking upgrade authorization and wallet minting uniqueness
- rename invariant placeholders to actual names

## Testing
- `FOUNDRY_INVARIANT_RUNS=10 forge test --match-contract AuditInvariant`

------
https://chatgpt.com/codex/tasks/task_e_684830dad52883278dec9533b97e806d