### PR TITLE
Add frontend linting config and CI step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,9 @@ jobs:
           corepack enable
           yarn install --frozen-lockfile
 
+      - name: Lint frontend
+        run: yarn --cwd packages/frontend lint
+
       - name: Install Python dependencies
         run: pip install -r packages/backend/requirements.txt
 

--- a/packages/frontend/.eslintrc.js
+++ b/packages/frontend/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['next', 'prettier'],
+};

--- a/packages/frontend/.prettierrc
+++ b/packages/frontend/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "printWidth": 80
+}

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -6,6 +6,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "format": "prettier --write .",
     "type-check": "tsc --noEmit",
     "test": "jest",
     "test:e2e": "cypress run",


### PR DESCRIPTION
## Summary
- add eslint and prettier configs for the frontend package
- add `format` script and keep lint script
- run lint in the CI workflow

## Testing
- `yarn --cwd packages/frontend install --immutable` *(fails: trouble with network connection)*
- `yarn --cwd packages/frontend lint` *(fails: `next` not found)*


------
https://chatgpt.com/codex/tasks/task_e_684830df865c83278c80bce46e504879