### PR TITLE
Add Sentry SDK integration

### DIFF
--- a/packages/backend/db.py
+++ b/packages/backend/db.py
@@ -4,6 +4,7 @@ from sqlalchemy import (
     Integer,
     String,
     BigInteger,
+    Text,
     Index,
 )
 from sqlalchemy.ext.declarative import declarative_base

--- a/packages/backend/main.py
+++ b/packages/backend/main.py
@@ -18,6 +18,8 @@ from eth_account.messages import encode_defunct
 from eth_abi import encode as abi_encode
 from web3.middleware import geth_poa_middleware
 import hashlib
+import sentry_sdk
+from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
 
 from .utils.ipfs import pin_json, cid_from_meta_hash, fetch_json
 from prometheus_fastapi_instrumentator import Instrumentator
@@ -27,6 +29,8 @@ from pythonjsonlogger import jsonlogger
 handler = logging.StreamHandler()
 handler.setFormatter(jsonlogger.JsonFormatter())
 logging.basicConfig(level=logging.INFO, handlers=[handler])
+
+sentry_sdk.init(dsn=os.getenv("SENTRY_DSN"))
 
 from .db import SessionLocal, Base, engine, Election as DbElection, ProofRequest, ProofAudit
 from .schemas import (
@@ -44,6 +48,7 @@ from sqlalchemy.exc import IntegrityError
 
 
 app = FastAPI()
+app.add_middleware(SentryAsgiMiddleware)
 
 Instrumentator().instrument(app).expose(app)
 

--- a/packages/backend/requirements.txt
+++ b/packages/backend/requirements.txt
@@ -16,3 +16,4 @@ requests
 base58
 prometheus-fastapi-instrumentator
 python-json-logger
+sentry-sdk


### PR DESCRIPTION
## Summary
- integrate Sentry SDK in backend
- expose Sentry middleware for FastAPI
- update backend requirements

## Testing
- `pip install -r packages/backend/requirements.txt`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'redis-server')*

------
https://chatgpt.com/codex/tasks/task_e_684830e1e68c832780b65fdfd4f96637