### PR TITLE
Add scheduled security scan workflow

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,37 @@
+name: Security Scan
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install pip-audit
+        run: pip install pip-audit
+
+      - name: Audit Python dependencies
+        run: pip-audit -r packages/backend/requirements.txt
+
+      - name: Install frontend dependencies
+        run: npm ci
+        working-directory: packages/frontend
+
+      - name: Audit Node dependencies
+        run: npm audit --audit-level=high
+        working-directory: packages/frontend


### PR DESCRIPTION
## Summary
- add a `security-scan` workflow to run `pip-audit` on backend deps and `npm audit` on frontend deps

## Testing
- `git status --porcelain`

------
https://chatgpt.com/codex/tasks/task_e_684830e4bfcc8327acff7126340df88c