### PR TITLE
Add Prettier support for frontend

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,3 +14,8 @@ repos:
         language_version: python3
         additional_dependencies: []
         files: ^packages/backend/|^services/
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.8.4
+    hooks:
+      - id: prettier
+        files: '^packages/frontend/.*\.(js|jsx|ts|tsx)$'

--- a/packages/frontend/.prettierrc
+++ b/packages/frontend/.prettierrc
@@ -1,5 +1,6 @@
 {
   "singleQuote": true,
   "trailingComma": "es5",
-  "printWidth": 80
+  "printWidth": 80,
+  "tabWidth": 2
 }

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -6,7 +6,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "format": "prettier --write .",
+    "format": "prettier --write \"src/**/*.{js,jsx,ts,tsx}\"",
+    "format:check": "prettier --check \"src/**/*.{js,jsx,ts,tsx}\"",
     "type-check": "tsc --noEmit",
     "test": "jest",
     "test:e2e": "cypress run",
@@ -44,6 +45,7 @@
     "jest-environment-jsdom": "^29.7.0",
     "postcss": "^8.4.38",
     "tailwindcss": "^3.4.3",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "prettier": "^2.8.8"
   }
 }


### PR DESCRIPTION
## Summary
- add Prettier configuration for frontend project
- expose `format` and `format:check` scripts
- enforce Prettier via pre-commit hooks

## Testing
- `npx prettier --write "src/**/*.{js,jsx,ts,tsx}"`
- `npx prettier --check "src/**/*.{js,jsx,ts,tsx}"`

------
https://chatgpt.com/codex/tasks/task_e_68483a145b348327a4e48db1b03061e5