### PR TITLE
Fix ensurePrefund call

### DIFF
--- a/packages/frontend/src/lib/accountAbstraction.ts
+++ b/packages/frontend/src/lib/accountAbstraction.ts
@@ -108,7 +108,7 @@ export async function bundleUserOp(
         pubSignals: eligibilityPubSignals,
     });
 
-    await ensurePrefund(api, signer, cfg);
+    await ensurePrefund(api, signer);
 
     const unsignedOp = await api.createUnsignedUserOp({
         target,


### PR DESCRIPTION
## Summary
- fix incorrect call to ensurePrefund in bundleUserOp

## Testing
- `npx tsc -p packages/frontend` *(fails: Cannot find module 'react')*
- `yarn --cwd packages/frontend build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684845d6650c8327b3709f5b733629a3