### PR TITLE
Fix security scan fails

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.11-slim AS base
-RUN apt-get update && apt-get install -y curl gnupg \
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y curl gnupg \
     && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
     && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- upgrade packages in Dockerfile during build for orchestrator image

## Testing
- `pre-commit run --files Dockerfile`

------
https://chatgpt.com/codex/tasks/task_e_68484eb413508327a425d51f53efcd68