### PR TITLE
Update Node and Python base images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [20]
+        node: [22]
         solc: ['0.8.26']
         python: ['3.11']
     timeout-minutes: 20
@@ -266,7 +266,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'yarn'
       - name: Install frontend dependencies
         run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install frontend dependencies
         run: corepack yarn@1.22.22 --cwd packages/frontend install

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
 
       - name: Install pip-audit

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -20,7 +20,7 @@ jobs:
       - name: 2. Install Language & Blockchain Toolchains
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
       - uses: actions/setup-python@v5
         with:
           python-version: 3.11

--- a/.github/workflows/solana.yml
+++ b/.github/workflows/solana.yml
@@ -22,7 +22,7 @@ jobs:
       # 2) install Node, Solana CLI & Anchor CLI
       - uses: metaDAOproject/setup-anchor@v3.1
         with:
-          node-version:       '20'
+          node-version:       '22'
           solana-cli-version: '1.18.18'
           anchor-version:     '0.30.1'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM python:3.11-slim AS base
+FROM python:3.11.13-slim AS base
 RUN apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y curl gnupg \
-    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
     && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/*
 RUN pip install --no-cache-dir --upgrade pip setuptools wheel

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,11 +1,11 @@
 # 1) Install dependencies inside a dedicated layer for caching
-FROM node:20-alpine AS deps
+FROM node:22-alpine AS deps
 WORKDIR /app/packages/frontend
 COPY packages/frontend/package.json packages/frontend/yarn.lock ./
 RUN yarn install --frozen-lockfile
 
 # 2) Create the final image
-FROM node:20-alpine AS runner
+FROM node:22-alpine AS runner
 WORKDIR /app
 
 # Copy the source code for the entire frontend application

--- a/services/relay-daemon/Dockerfile
+++ b/services/relay-daemon/Dockerfile
@@ -1,5 +1,5 @@
 # services/relay-daemon/Dockerfile
-FROM node:20-alpine
+FROM node:22-alpine
 
 # Set the working directory inside the container
 WORKDIR /app


### PR DESCRIPTION
## Summary
- update Docker base images to latest Node 22 and Python 3.11.13
- upgrade Node versions in Dockerfiles
- bump Node versions in workflows

## Testing
- `npm test` *(fails: PAYMASTER_ADDR unbound variable)*
- `pytest` *(fails: ModuleNotFoundError: httpx)*


------
https://chatgpt.com/codex/tasks/task_e_68485acafcb48327a6eb751f2638eb6b