### PR TITLE
Fix Trivy install step in security scan workflow

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -47,7 +47,7 @@ jobs:
         run: docker compose build orchestrator
 
       - name: Install Trivy
-        uses: aquasecurity/trivy-action@0.31.0
+        uses: aquasecurity/setup-trivy@v1
 
       - name: Run Trivy scan
         run: ./scripts/scan-trivy.sh toting-orchestrator


### PR DESCRIPTION
## Summary
- use setup-trivy in security scan workflow

## Testing
- `pre-commit run --files .github/workflows/security-scan.yml`
- `pytest -q packages/backend/tests/test_main.py` *(fails: ImportError: cannot import name 'geth_poa_middleware')*

------
https://chatgpt.com/codex/tasks/task_e_68486b7ced3083279285aaaff60d7b0d