### PR TITLE
Update Node and packages in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 FROM python:3.11.13-slim AS base
 RUN apt-get update \
-    && apt-get upgrade -y \
-    && apt-get install -y curl gnupg \
-    && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
-    && apt-get install -y nodejs \
+    && apt-get dist-upgrade -y \
+    && apt-get install -y --no-install-recommends curl gnupg \
+    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && apt-get purge -y curl gnupg \
+    && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*
 RUN pip install --no-cache-dir --upgrade pip setuptools wheel
 WORKDIR /app


### PR DESCRIPTION
## Summary
- run dist-upgrade when building the base image
- switch to Node 20 for fewer vulnerabilities
- purge build packages after install

## Testing
- `pre-commit run --files Dockerfile`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68486eebd87c83279d77ae2b30eedef0