### PR TITLE
Implement UX-02 Mock Login Modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ See [docs/handbook](docs/handbook/README.md) for instructions on running service
 Copy `.env.example` to `.env` and update the values before starting the stack. The backend refuses to run with the placeholder secrets when `USE_REAL_OAUTH=true`.
 
 The backend exposes a simple mock OAuth login for local testing. By default
-`docker-compose` starts the API with `USE_REAL_OAUTH=false`, serving a minimal
-form at `/auth/initiate` that lets you enter an email. Set
+`docker-compose` starts the API with `USE_REAL_OAUTH=false`. The frontend
+intercepts `/auth/initiate` and shows a **Mock Login** modal instead of
+navigating to the raw HTML form. Set
 `USE_REAL_OAUTH=true` to redirect to the configured `GRAO_BASE_URL` instead. The
 `GRAO_REDIRECT_URI` environment variable should match your frontend callback
 page (by default `http://localhost:3000/auth/callback`).
@@ -41,7 +42,7 @@ The backend exposes several REST endpoints used by the frontend:
 
 | Method | Path | Description |
 |-------|------|-------------|
-| `GET` | `/auth/initiate` | Start OAuth login (mock form in local mode). |
+| `GET` | `/auth/initiate` | Start OAuth login (returns mock form in local mode; shown via modal). |
 | `GET` | `/auth/callback` | Finalize login, returns `{id_token, eligibility}`. |
 | `GET` | `/elections` | List elections. |
 | `POST` | `/elections` | Create a new election. |

--- a/packages/frontend/src/components/MockLoginModal.tsx
+++ b/packages/frontend/src/components/MockLoginModal.tsx
@@ -9,6 +9,8 @@ export default function MockLoginModal({ onClose }: { onClose: () => void }) {
   const emailRef = useRef<HTMLInputElement>(null);
   const submitRef = useRef<HTMLButtonElement>(null);
   const cancelRef = useRef<HTMLButtonElement>(null);
+  const emailRegex = /^[^@]+@[^@]+\.[^@]+$/;
+  const isValid = emailRegex.test(email);
 
   useEffect(() => {
     emailRef.current?.focus();
@@ -33,7 +35,7 @@ export default function MockLoginModal({ onClose }: { onClose: () => void }) {
   }, [onClose]);
 
   const submit = async () => {
-    if (!/^[^@]+@[^@]+\.[^@]+$/.test(email)) { setError('invalid email'); return; }
+    if (!isValid) { setError('invalid email'); return; }
     const res = await fetch(`${apiUrl('/auth/callback')}?user=${encodeURIComponent(email)}`);
     const data = await res.json();
     if (data.id_token) {
@@ -46,6 +48,7 @@ export default function MockLoginModal({ onClose }: { onClose: () => void }) {
 
   return (
     <div
+      onClick={e => { if (e.target === e.currentTarget) onClose(); }}
       style={{
         position: 'fixed',
         top: 0,
@@ -59,6 +62,7 @@ export default function MockLoginModal({ onClose }: { onClose: () => void }) {
       }}
     >
       <div
+        onClick={e => e.stopPropagation()}
         role="dialog"
         aria-modal="true"
         aria-labelledby="mocklogin-title"
@@ -73,11 +77,11 @@ export default function MockLoginModal({ onClose }: { onClose: () => void }) {
           ref={emailRef}
           type="email"
           value={email}
-          onChange={(e) => setEmail(e.target.value)}
+          onChange={(e) => { setEmail(e.target.value); if (error) setError(''); }}
           placeholder="Email"
         />
         <div style={{ display: 'flex', gap: '0.5rem', marginTop: '0.5rem' }}>
-          <button ref={submitRef} onClick={submit} aria-label="Submit mock login">
+          <button ref={submitRef} onClick={submit} disabled={!isValid} aria-label="Submit mock login">
             Login
           </button>
           <button ref={cancelRef} onClick={onClose} aria-label="Cancel mock login">

--- a/packages/frontend/src/pages/login.tsx
+++ b/packages/frontend/src/pages/login.tsx
@@ -33,12 +33,8 @@ export default function LoginPage() {
       const res = await fetch(apiUrl('/auth/initiate'), { redirect: 'manual' });
       const location = res.status >= 300 && res.status < 400 ? res.headers.get('Location') : undefined;
       if (res.ok && res.headers.get('content-type')?.includes('text/html') && !location) {
-        const html = await res.text();
-        const popup = window.open('', 'login', 'width=500,height=600');
-        if (popup) {
-          popup.document.write(html);
-          popup.document.close();
-        }
+        // Backend is in mock mode – show the modal instead of the raw HTML form.
+        openMock();
         return;
       }
       const url = location || apiUrl('/auth/initiate');


### PR DESCRIPTION
## Summary
- switch mock login flow to in-app modal when `/auth/initiate` returns HTML
- add outside click handler and validation to `MockLoginModal`
- document modal behaviour in README

## Testing
- `yarn test` *(fails: useI18n must be used within an I18nProvider)*
- `pytest` *(fails: ModuleNotFoundError: 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_684ed4ae0898832781b0f3e52b5a535d