### PR TITLE
Add skeleton states for admin pages

### DIFF
--- a/packages/frontend/src/pages/admin/elections/[id].tsx
+++ b/packages/frontend/src/pages/admin/elections/[id].tsx
@@ -5,6 +5,7 @@ import withAuth from '../../../components/withAuth';
 import { useAuth } from '../../../lib/AuthProvider';
 import { jsonFetcher } from '../../../lib/api';
 import AdminStatusForm from '../../../components/AdminStatusForm';
+import Skeleton from '../../../components/Skeleton';
 
 interface Election {
   id: number;
@@ -27,7 +28,17 @@ function AdminElectionDetail() {
       <NavBar />
       <div style={{ padding: '1rem' }}>
         {!data ? (
-          <p>Loading...</p>
+          <div>
+            <h2>
+              <Skeleton width={120} height={20} />
+            </h2>
+            <p>
+              <Skeleton width={180} height={16} />
+            </p>
+            <p>
+              <Skeleton width={180} height={16} />
+            </p>
+          </div>
         ) : (
           <div>
             <h2>Election {data.id}</h2>

--- a/packages/frontend/src/pages/admin/index.tsx
+++ b/packages/frontend/src/pages/admin/index.tsx
@@ -4,6 +4,7 @@ import withAuth from '../../components/withAuth';
 import { useAuth } from '../../lib/AuthProvider';
 import { jsonFetcher } from '../../lib/api';
 import AdminElectionList, { AdminElection } from '../../components/AdminElectionList';
+import Skeleton from '../../components/Skeleton';
 
 const fetcher = ([url, token]: [string, string]) => jsonFetcher([url, token]);
 
@@ -21,7 +22,34 @@ function AdminDashboard() {
       <NavBar />
       <div style={{ padding: '1rem' }}>
         <h2>Admin Dashboard</h2>
-        {!data ? <p>Loading...</p> : <AdminElectionList elections={data} />}
+        {!data ? (
+          <table>
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>Status</th>
+                <th>Tally</th>
+              </tr>
+            </thead>
+            <tbody>
+              {[1, 2, 3].map((i) => (
+                <tr key={i}>
+                  <td>
+                    <Skeleton width={20} height={16} />
+                  </td>
+                  <td>
+                    <Skeleton width={80} height={16} />
+                  </td>
+                  <td>
+                    <Skeleton width={80} height={16} />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : (
+          <AdminElectionList elections={data} />
+        )}
       </div>
     </>
   );


### PR DESCRIPTION
## Summary
- add shimmer loader on the admin dashboard election list
- show skeleton placeholders when loading admin election details

## Testing
- `npx jest` *(fails: Cannot find module 'next-router-mock')*


------
https://chatgpt.com/codex/tasks/task_e_684ed4bb93488327b591763b8da7ff5f