### PR TITLE
Add 32-bit range gadget and fuzz harness

### DIFF
--- a/circuits/gadgets/range32.circom
+++ b/circuits/gadgets/range32.circom
@@ -1,0 +1,20 @@
+pragma circom 2.2.2;
+
+include "../circomlib/circuits/bitify.circom";
+
+// Range check gadget ensuring 0 <= value <= 2^32 - 1.
+// It exposes a single output `ok` that is 1 when the
+// constraint is satisfied.
+template RangeCheck32() {
+    signal input value;
+    signal output ok;
+
+    // Convert the value to 32 bits. Num2Bits enforces that
+    // all higher bits are zero and each bit is boolean.
+    component bits = Num2Bits(32);
+    bits.in <== value;
+
+    ok <== 1;
+}
+
+component main = RangeCheck32();

--- a/test/setupEnvRedeploy.test.js
+++ b/test/setupEnvRedeploy.test.js
@@ -9,7 +9,7 @@ const appLink = '/app';
 if (!fs.existsSync(appLink)) fs.symlinkSync(root, appLink);
 
 const envFile = path.join(appLink, '.env');
-fs.writeFileSync(envFile, 'ORCHESTRATOR_KEY=0x01\n');
+fs.writeFileSync(envFile, 'ORCHESTRATOR_KEY=0x01\nSOLANA_BRIDGE_SK=[]\n');
 
 const deployedFile = path.join(appLink, '.env.deployed');
 fs.writeFileSync(deployedFile, 'ELECTION_MANAGER=0x0\nNEXT_PUBLIC_ELECTION_MANAGER=0x0\nNEXT_PUBLIC_WALLET_FACTORY=0x0\nNEXT_PUBLIC_ENTRYPOINT=0x0\n');

--- a/test/setupEnvReuse.test.js
+++ b/test/setupEnvReuse.test.js
@@ -16,7 +16,7 @@ try {
 }
 
 const envFile = path.join(appLink, '.env');
-fs.writeFileSync(envFile, 'ORCHESTRATOR_KEY=0x01\n');
+fs.writeFileSync(envFile, 'ORCHESTRATOR_KEY=0x01\nSOLANA_BRIDGE_SK=[]\n');
 
 const deployedFile = path.join(appLink, '.env.deployed');
 const ADDR_ENTRY = '0x1111111111111111111111111111111111111111';

--- a/test/signalRange.test.js
+++ b/test/signalRange.test.js
@@ -1,0 +1,57 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execSync } = require('child_process');
+
+function run(cmd) {
+  execSync(cmd, { stdio: 'inherit' });
+}
+
+(async () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'range32-'));
+  const circuitPath = path.join(__dirname, '..', 'circuits', 'gadgets', 'range32.circom');
+
+  run(`npx -y circom2 ${circuitPath} --wasm --r1cs -o ${tmp}`);
+
+  const wasm = path.join(tmp, 'range32_js', 'range32.wasm');
+  const gen = path.join(tmp, 'range32_js', 'generate_witness.js');
+  const r1cs = path.join(tmp, 'range32.r1cs');
+  const inputFile = path.join(tmp, 'input.json');
+  const witness = path.join(tmp, 'witness.wtns');
+
+  const MAX = 2 ** 32 - 1;
+  const NUM_RUNS = 50;
+  let falseNeg = 0;
+  let falsePos = 0;
+
+  for (let i = 0; i < NUM_RUNS; i++) {
+    const val = Math.floor(Math.random() * (MAX + 1));
+    fs.writeFileSync(inputFile, JSON.stringify({ value: val }));
+    try {
+      run(`node ${gen} ${wasm} ${inputFile} ${witness}`);
+      run(`npx -y snarkjs wtns check ${r1cs} ${witness}`);
+    } catch (e) {
+      falseNeg++;
+    }
+  }
+
+  for (let i = 0; i < NUM_RUNS; i++) {
+    const val = MAX + 1 + Math.floor(Math.random() * 100000);
+    fs.writeFileSync(inputFile, JSON.stringify({ value: val }));
+    let passed = true;
+    try {
+      run(`node ${gen} ${wasm} ${inputFile} ${witness}`);
+      run(`npx -y snarkjs wtns check ${r1cs} ${witness}`);
+    } catch (e) {
+      passed = false;
+    }
+    if (passed) falsePos++;
+  }
+
+  if (falseNeg !== 0 || falsePos !== 0) {
+    console.error(`falseNeg=${falseNeg} falsePos=${falsePos}`);
+    process.exit(1);
+  }
+
+  console.log('signal range fuzz test passed');
+})();


### PR DESCRIPTION
## Summary
- create `RangeCheck32` gadget for 0 ≤ value < 2^32
- add fuzz harness exercising the gadget
- populate missing env var in setup tests

## Testing
- `npm test` *(fails: Property 'providers' does not exist on type 'ethers')*

------
https://chatgpt.com/codex/tasks/task_e_684edce961c88327b60458b4a94b0953