### PR TITLE
Implement curve-aware factory deployment

### DIFF
--- a/contracts/VerifierBLS.sol
+++ b/contracts/VerifierBLS.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "./Verifier.sol";
+
+/// @title BLS12-381 proof verifier stub
+/// @notice Placeholder verifier used when deploying with curve BLS12-381.
+contract VerifierBLS is Verifier {
+    /// @dev Always returns true. Replace with real verification logic for
+    /// production deployments.
+    function verifyProof(
+        uint256[2] calldata,
+        uint256[2][2] calldata,
+        uint256[2] calldata,
+        uint256[7] calldata
+    ) public pure override returns (bool) {
+        return true;
+    }
+}

--- a/contracts/WalletFactory.sol
+++ b/contracts/WalletFactory.sol
@@ -15,6 +15,8 @@ contract WalletFactory {
     EntryPoint public entryPoint;
     /// @notice Proof verifier contract
     Verifier public verifier;
+    /// @notice Curve identifier (bn254 or bls12-381)
+    string public curve;
     /// @notice Tracks the wallet deployed for each EOA
     mapping(address => address) public walletOf;
 
@@ -22,9 +24,11 @@ contract WalletFactory {
 
     /// @param _entryPoint Address of the ERC‑4337 entry point
     /// @param _verifier Zero‑knowledge proof verifier
-    constructor(EntryPoint _entryPoint, Verifier _verifier) {
+    /// @param _curve Curve identifier string
+    constructor(EntryPoint _entryPoint, Verifier _verifier, string memory _curve) {
         entryPoint = _entryPoint;
         verifier = _verifier;
+        curve = _curve;
     }
 
     /// @notice Deploy a wallet using ABI‑encoded proof parameters

--- a/test/AuditInvariant.t.sol
+++ b/test/AuditInvariant.t.sol
@@ -41,7 +41,7 @@ contract AuditInvariant is Test {
 
         entryPoint = new EntryPoint();
         verifier = new TestVerifier();
-        factory = new WalletFactory(entryPoint, verifier);
+        factory = new WalletFactory(entryPoint, verifier, "bn254");
 
         ElectionManagerV2 implementation = new ElectionManagerV2();
         MockMACI maci = new MockMACI();

--- a/test/FuzzAndInvariant.t.sol
+++ b/test/FuzzAndInvariant.t.sol
@@ -26,7 +26,7 @@ contract FuzzAndInvariantTest is Test {
     function setUp() public {
         entryPoint = new EntryPoint();
         verifier = new TestVerifier();
-        factory = new WalletFactory(entryPoint, verifier);
+        factory = new WalletFactory(entryPoint, verifier, "bn254");
     }
     
     function testFuzz_MintWallet(address owner, uint256 salt) public {

--- a/test/SmokeTests.t.sol
+++ b/test/SmokeTests.t.sol
@@ -28,7 +28,7 @@ contract SmokeTests is Test {
     function setUp() public {
         entryPoint = new EntryPoint();
         verifier = new TestVerifier();
-        factory = new WalletFactory(entryPoint, verifier);
+        factory = new WalletFactory(entryPoint, verifier, "bn254");
     }
 
     function test_MintWallet() public {

--- a/test/WalletFactoryDeterminism.t.sol
+++ b/test/WalletFactoryDeterminism.t.sol
@@ -30,7 +30,7 @@ contract WalletFactoryDeterminismTest is Test {
     function setUp() public {
         entryPoint = new EntryPoint();
         verifier = new TestVerifier();
-        factory = new WalletFactory(entryPoint, verifier);
+        factory = new WalletFactory(entryPoint, verifier, "bn254");
     }
 
     function test_DeterministicAddress() public {

--- a/test/integration/FullFlow.t.sol
+++ b/test/integration/FullFlow.t.sol
@@ -53,7 +53,7 @@ contract FullFlowTest is Test {
     function setUp() public {
         entryPoint = new EntryPoint();
         maci       = new MockMACI();
-        factory    = new WalletFactory(entryPoint, new TestVerifier());
+        factory    = new WalletFactory(entryPoint, new TestVerifier(), "bn254");
 
         // ── Deploy upgradeable manager (proxy + impl) ──────────────────────
         ElectionManagerV2 impl = new ElectionManagerV2();


### PR DESCRIPTION
## Summary
- add stub BLS12-381 verifier
- let WalletFactory store the selected curve
- choose curve on DeployFactory script via `CURVE` env var
- update Foundry tests for new constructor

## Testing
- `pre-commit run --files contracts/VerifierBLS.sol contracts/WalletFactory.sol script/DeployFactory.s.sol test/SmokeTests.t.sol test/WalletFactoryDeterminism.t.sol test/integration/FullFlow.t.sol test/AuditInvariant.t.sol test/FuzzAndInvariant.t.sol`
- `forge build`
- `forge test` *(fails: FailedOp and job killed)*

------
https://chatgpt.com/codex/tasks/task_e_684edcfcb4d48327bf3663089032432f