### PR TITLE
Implement Timelock upgrade flow

### DIFF
--- a/docs/handbook/README.md
+++ b/docs/handbook/README.md
@@ -109,6 +109,7 @@ Individual scripts can be run with:
 
 ```bash
 forge script script/DeployFactory.s.sol --fork-url $RPC_URL --broadcast
+forge script script/DeployTimelockManager.s.sol --fork-url $RPC_URL --broadcast
 ```
 
 ## Regenerating Proofs

--- a/script/DeployTimelockManager.s.sol
+++ b/script/DeployTimelockManager.s.sol
@@ -1,0 +1,44 @@
+// script/DeployTimelockManager.s.sol
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Script.sol";
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import "@openzeppelin/contracts/governance/TimelockController.sol";
+import "../contracts/ElectionManagerV2.sol";
+import "../contracts/MockMACI.sol";
+import "../contracts/interfaces/IMACI.sol";
+
+contract DeployTimelockManager is Script {
+    function run() external returns (address proxyAddr, address timelockAddr) {
+        uint256 deployerPrivateKey = vm.envUint("ORCHESTRATOR_KEY");
+        require(deployerPrivateKey != 0, "ORCHESTRATOR_KEY env var not set");
+
+        address deployer = vm.addr(deployerPrivateKey);
+
+        vm.startBroadcast(deployerPrivateKey);
+
+        MockMACI maci = new MockMACI();
+        console.log("MockMACI deployed to:", address(maci));
+
+        ElectionManagerV2 implementation = new ElectionManagerV2();
+        console.log("ElectionManagerV2 implementation deployed to:", address(implementation));
+
+        bytes memory callData = abi.encodeWithSignature("initialize(address,address)", address(maci), deployer);
+        ERC1967Proxy proxy = new ERC1967Proxy(address(implementation), callData);
+        proxyAddr = address(proxy);
+        console.log("ElectionManagerV2 proxy deployed to:", proxyAddr);
+
+        address[] memory proposers = new address[](1);
+        proposers[0] = deployer;
+        address[] memory executors = new address[](1);
+        executors[0] = deployer;
+        TimelockController timelock = new TimelockController(1 days, proposers, executors, deployer);
+        timelockAddr = address(timelock);
+        console.log("TimelockController deployed to:", timelockAddr);
+
+        ElectionManagerV2(address(proxy)).transferOwnership(timelockAddr);
+
+        vm.stopBroadcast();
+    }
+}

--- a/test/TimelockUpgrade.t.sol
+++ b/test/TimelockUpgrade.t.sol
@@ -1,0 +1,63 @@
+// test/TimelockUpgrade.t.sol
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {TimelockController} from "@openzeppelin/contracts/governance/TimelockController.sol";
+
+import {ElectionManagerV2} from "../contracts/ElectionManagerV2.sol";
+import {MockMACI} from "../contracts/MockMACI.sol";
+import {IMACI} from "../contracts/interfaces/IMACI.sol";
+
+contract TimelockUpgradeTest is Test {
+    ElectionManagerV2 public manager;
+    TimelockController public timelock;
+    address internal owner;
+
+    function setUp() public {
+        owner = address(this);
+
+        ElectionManagerV2 implementation = new ElectionManagerV2();
+        MockMACI maci = new MockMACI();
+        bytes memory data = abi.encodeCall(ElectionManagerV2.initialize, (IMACI(address(maci)), owner));
+        ERC1967Proxy proxy = new ERC1967Proxy(address(implementation), data);
+        manager = ElectionManagerV2(address(proxy));
+
+        address[] memory proposers = new address[](1);
+        proposers[0] = owner;
+        address[] memory executors = new address[](1);
+        executors[0] = owner;
+        timelock = new TimelockController(1 days, proposers, executors, owner);
+
+        manager.transferOwnership(address(timelock));
+    }
+
+    function _impl() internal view returns (address impl) {
+        bytes32 slot = bytes32(uint256(keccak256("eip1967.proxy.implementation")) - 1);
+        bytes32 data = vm.load(address(manager), slot);
+        impl = address(uint160(uint256(data)));
+    }
+
+    function test_upgradeThroughTimelock() public {
+        address implBefore = _impl();
+        ElectionManagerV2 newImpl = new ElectionManagerV2();
+
+        bytes memory callData = abi.encodeWithSelector(manager.upgradeTo.selector, address(newImpl));
+        bytes32 salt = bytes32(0);
+        timelock.schedule(address(manager), 0, callData, bytes32(0), salt, 1 days);
+
+        vm.warp(block.timestamp + 1 days + 1);
+        timelock.execute(address(manager), 0, callData, bytes32(0), salt);
+
+        address implAfter = _impl();
+        assertEq(implAfter, address(newImpl));
+        assertTrue(implBefore != implAfter);
+    }
+
+    function test_directUpgradeBlocked() public {
+        ElectionManagerV2 newImpl = new ElectionManagerV2();
+        vm.expectRevert("Ownable: caller is not the owner");
+        manager.upgradeTo(address(newImpl));
+    }
+}


### PR DESCRIPTION
## Summary
- create `DeployTimelockManager` script deploying a timelock and transferring `ElectionManagerV2` ownership
- add a dedicated timelock upgrade test
- document how to run the new deployment script in the handbook

## Testing
- `forge test --match-path test/TimelockUpgrade.t.sol -vv`
- `forge test -vvv` *(fails: process killed)*

------
https://chatgpt.com/codex/tasks/task_e_684ee59a835483279a02c402c13f200d