### PR TITLE
Add DAO for on-chain election creation

### DIFF
--- a/contracts/TotingDAO.sol
+++ b/contracts/TotingDAO.sol
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts/governance/Governor.sol";
+import "@openzeppelin/contracts/governance/extensions/GovernorCountingSimple.sol";
+import "@openzeppelin/contracts/governance/extensions/GovernorTimelockControl.sol";
+import "@openzeppelin/contracts/governance/extensions/GovernorVotes.sol";
+import "@openzeppelin/contracts/governance/extensions/GovernorVotesQuorumFraction.sol";
+
+/// @title Governance contract controlling election creation
+contract TotingDAO is
+    Governor,
+    GovernorTimelockControl,
+    GovernorVotes,
+    GovernorVotesQuorumFraction,
+    GovernorCountingSimple
+{
+    constructor(IVotes _token, TimelockController _timelock)
+        Governor("TotingDAO")
+        GovernorVotes(_token)
+        GovernorVotesQuorumFraction(4)
+        GovernorTimelockControl(_timelock)
+    {}
+
+    function votingDelay() public pure override returns (uint256) {
+        return 1; // 1 block
+    }
+
+    function votingPeriod() public pure override returns (uint256) {
+        return 45818; // ~1 week
+    }
+
+    // The following functions are overrides required by Solidity.
+    function quorum(uint256 blockNumber)
+        public
+        view
+        override(IGovernor, GovernorVotesQuorumFraction)
+        returns (uint256)
+    {
+        return super.quorum(blockNumber);
+    }
+
+    function state(uint256 proposalId)
+        public
+        view
+        override(Governor, GovernorTimelockControl)
+        returns (ProposalState)
+    {
+        return super.state(proposalId);
+    }
+
+    function propose(
+        address[] memory targets,
+        uint256[] memory values,
+        bytes[] memory calldatas,
+        string memory description
+    ) public override(Governor, IGovernor) returns (uint256) {
+        return super.propose(targets, values, calldatas, description);
+    }
+
+    function _execute(
+        uint256 proposalId,
+        address[] memory targets,
+        uint256[] memory values,
+        bytes[] memory calldatas,
+        bytes32 descriptionHash
+    ) internal override(Governor, GovernorTimelockControl) {
+        super._execute(proposalId, targets, values, calldatas, descriptionHash);
+    }
+
+    function _cancel(
+        address[] memory targets,
+        uint256[] memory values,
+        bytes[] memory calldatas,
+        bytes32 descriptionHash
+    ) internal override(Governor, GovernorTimelockControl) returns (uint256) {
+        return super._cancel(targets, values, calldatas, descriptionHash);
+    }
+
+    function _executor() internal view override(Governor, GovernorTimelockControl) returns (address) {
+        return super._executor();
+    }
+
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        override(Governor, GovernorTimelockControl)
+        returns (bool)
+    {
+        return super.supportsInterface(interfaceId);
+    }
+}

--- a/contracts/TotingToken.sol
+++ b/contracts/TotingToken.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Votes.sol";
+
+/// @title Simple governance token for the TotingDAO
+contract TotingToken is ERC20, ERC20Permit, ERC20Votes {
+    constructor() ERC20("TotingToken", "TOT") ERC20Permit("TotingToken") {}
+
+    /// @notice Mint tokens for testing or initial distribution
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    // The functions below are overrides required by Solidity.
+    function _afterTokenTransfer(address from, address to, uint256 amount) internal override(ERC20, ERC20Votes) {
+        super._afterTokenTransfer(from, to, amount);
+    }
+
+    function _mint(address to, uint256 amount) internal override(ERC20, ERC20Votes) {
+        super._mint(to, amount);
+    }
+
+    function _burn(address account, uint256 amount) internal override(ERC20, ERC20Votes) {
+        super._burn(account, amount);
+    }
+}

--- a/test/TotingDAO.t.sol
+++ b/test/TotingDAO.t.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {TotingToken} from "../contracts/TotingToken.sol";
+import {TotingDAO} from "../contracts/TotingDAO.sol";
+import {ElectionManagerV2} from "../contracts/ElectionManagerV2.sol";
+import {MockMACI} from "../contracts/MockMACI.sol";
+import {IMACI} from "../contracts/interfaces/IMACI.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {TimelockController} from "@openzeppelin/contracts/governance/TimelockController.sol";
+
+contract TotingDAOTest is Test {
+    TotingToken token;
+    TimelockController timelock;
+    TotingDAO dao;
+    ElectionManagerV2 manager;
+
+    function setUp() public {
+        token = new TotingToken();
+        timelock = new TimelockController(0, new address[](0), new address[](0), address(this));
+        dao = new TotingDAO(token, timelock);
+
+        timelock.grantRole(timelock.PROPOSER_ROLE(), address(dao));
+        timelock.grantRole(timelock.EXECUTOR_ROLE(), address(dao));
+
+        token.mint(address(this), 1 ether);
+        token.delegate(address(this));
+
+        ElectionManagerV2 impl = new ElectionManagerV2();
+        MockMACI maci = new MockMACI();
+        bytes memory data = abi.encodeCall(ElectionManagerV2.initialize, (IMACI(address(maci)), address(timelock)));
+        ERC1967Proxy proxy = new ERC1967Proxy(address(impl), data);
+        manager = ElectionManagerV2(address(proxy));
+    }
+
+    function testGovernedElectionCreation() public {
+        address[] memory targets = new address[](1);
+        targets[0] = address(manager);
+        uint256[] memory values = new uint256[](1);
+        bytes[] memory calldatas = new bytes[](1);
+        bytes32 meta = bytes32(uint256(0x42));
+        calldatas[0] = abi.encodeCall(ElectionManagerV2.createElection, (meta));
+        string memory desc = "create election";
+
+        uint256 id = dao.propose(targets, values, calldatas, desc);
+
+        vm.roll(block.number + dao.votingDelay() + 1);
+        dao.castVote(id, 1);
+        vm.roll(block.number + dao.votingPeriod() + 1);
+        vm.warp(block.timestamp + 1);
+
+        assertEq(uint256(dao.state(id)), 4); // Succeeded
+
+        dao.queue(targets, values, calldatas, keccak256(bytes(desc)));
+        dao.execute(targets, values, calldatas, keccak256(bytes(desc)));
+
+        assertEq(manager.nextId(), 1);
+    }
+}


### PR DESCRIPTION
## Summary
- add `TotingDAO` governor contract using OpenZeppelin modules
- add `TotingToken` governance token for voting
- test DAO creates a new election via timelock

## Testing
- `FOUNDRY_VIA_IR=false forge test --match-contract TotingDAOTest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ee5605b748327ab4e624ce0ecff0b