### PR TITLE
Add pluggable voting strategies

### DIFF
--- a/contracts/interfaces/IVotingStrategy.sol
+++ b/contracts/interfaces/IVotingStrategy.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/// @title Interface for pluggable voting strategies
+/// @notice Implementations verify tally proofs for a specific voting method
+interface IVotingStrategy {
+    /// @notice Verify a tally proof and return the resulting tally numbers
+    /// @param a Groth16 proof A
+    /// @param b Groth16 proof B
+    /// @param c Groth16 proof C
+    /// @param pubSignals Arbitrary length public inputs for the proof
+    /// @return tally Array containing the tally result
+    function tallyVotes(
+        uint256[2] calldata a,
+        uint256[2][2] calldata b,
+        uint256[2] calldata c,
+        uint256[] calldata pubSignals
+    ) external view returns (uint256[2] memory tally);
+}

--- a/contracts/strategies/QuadraticVotingStrategy.sol
+++ b/contracts/strategies/QuadraticVotingStrategy.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "../TallyVerifier.sol";
+import "../interfaces/IVotingStrategy.sol";
+
+/// @title Quadratic Voting strategy
+/// @notice Default voting strategy using a Groth16 tally proof
+contract QuadraticVotingStrategy is IVotingStrategy {
+    TallyVerifier public immutable verifier;
+
+    constructor(TallyVerifier _verifier) {
+        verifier = _verifier;
+    }
+
+    /// @inheritdoc IVotingStrategy
+    function tallyVotes(
+        uint256[2] calldata a,
+        uint256[2][2] calldata b,
+        uint256[2] calldata c,
+        uint256[] calldata pubSignals
+    ) external view override returns (uint256[2] memory tally) {
+        require(pubSignals.length == 7, "bad-len");
+        uint256[7] memory inputs;
+        for (uint256 i = 0; i < 7; i++) {
+            inputs[i] = pubSignals[i];
+        }
+        require(verifier.verifyProof(a, b, c, inputs), "invalid tally proof");
+        tally[0] = pubSignals[0];
+        tally[1] = pubSignals[1];
+    }
+}

--- a/packages/backend/main.py
+++ b/packages/backend/main.py
@@ -371,7 +371,10 @@ def create_election(
         # we manually encode the calldata. This is the Python equivalent of the
         # `abi.encodeCall` fix already present in your `FullFlow.t.sol` test.
         # This ensures the proxy receives the exact, intended function call.
-        encoded_calldata = contract.encodeABI(fn_name='createElection', args=[meta_hash])
+        encoded_calldata = contract.encodeABI(
+            fn_name='createElection',
+            args=[meta_hash, '0x0000000000000000000000000000000000000000']
+        )
 
         tx = {
             "to": ELECTION_MANAGER, # The address of the proxy contract

--- a/script/TestCreateElection.s.sol
+++ b/script/TestCreateElection.s.sol
@@ -6,6 +6,7 @@ pragma solidity ^0.8.24;
 import "forge-std/Test.sol";
 import "forge-std/console.sol";
 import "../contracts/ElectionManagerV2.sol";
+import "../contracts/interfaces/IVotingStrategy.sol";
 
 // --- FIX: Inherit from Test instead of Script ---
 contract TestCreateElection is Test {
@@ -34,7 +35,7 @@ contract TestCreateElection is Test {
         
         console.log("Broadcasting createElection transaction as owner:", deployer);
         vm.startBroadcast(deployerPrivateKey);
-        manager.createElection(meta);
+        manager.createElection(meta, IVotingStrategy(address(0)));
         vm.stopBroadcast();
         console.log("Transaction broadcasted.");
 

--- a/scripts/test_election_flow.tsx
+++ b/scripts/test_election_flow.tsx
@@ -83,7 +83,7 @@ async function main() {
   // 2. Test the ElectionManager interactions
   const mgr = new ethers.Contract(EMGR!, EMGR_ABI, wallet);
   const meta = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('demo-election'));
-  const tx2 = await mgr.createElection(meta, { gasLimit: 5_000_000 });
+  const tx2 = await mgr.createElection(meta, ethers.constants.AddressZero, { gasLimit: 5_000_000 });
   console.log('⏳ createElection tx', tx2.hash);
   const rcpt2 = await tx2.wait();
   const evt2 = rcpt2.logs.map(l => mgr.interface.parseLog(l)).find(e => e.name === 'ElectionCreated');


### PR DESCRIPTION
## Summary
- implement `IVotingStrategy` interface
- add `QuadraticVotingStrategy` contract implementing the interface
- update `ElectionManagerV2` to support per‑election strategies
- adjust scripts and tests for the new `createElection` signature
- update backend and demo scripts for compatibility

## Testing
- `forge test` *(fails: environment variable not set)*

------
https://chatgpt.com/codex/tasks/task_e_684ee558463083278fd75500d0179e0f