### PR TITLE
Add download script for voice keys

### DIFF
--- a/.github/workflows/voice-keys.yml
+++ b/.github/workflows/voice-keys.yml
@@ -1,0 +1,15 @@
+name: Fetch Voice Keys
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'scripts/fetch_voice_keys.sh'
+
+jobs:
+  fetch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run fetch script
+        run: scripts/fetch_voice_keys.sh

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ package-lock.json
 packages/backend/__pycache__/
 target/
 examples/wtns/
+
+# Voice check proving key files
+proofs/voice_check_final.zkey
+proofs/voice_verification_key.json

--- a/scripts/fetch_voice_keys.sh
+++ b/scripts/fetch_voice_keys.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DEST_DIR="${1:-proofs}"
+mkdir -p "$DEST_DIR"
+
+ZKEY_URL="${VOICE_ZKEY_URL:-https://storage.googleapis.com/toting-proving-keys/voice_check_final.zkey}"
+VKEY_URL="${VOICE_VKEY_URL:-https://storage.googleapis.com/toting-proving-keys/voice_verification_key.json}"
+
+curl -L "$ZKEY_URL" -o "$DEST_DIR/voice_check_final.zkey"
+curl -L "$VKEY_URL" -o "$DEST_DIR/voice_verification_key.json"
+
+ls -lh "$DEST_DIR"/voice_check_final.zkey "$DEST_DIR/voice_verification_key.json"


### PR DESCRIPTION
## Summary
- remove voice zkey and verification key from repo
- add script to fetch voice zkey and vkey
- add workflow that runs the script
- ignore downloaded voice keys

## Testing
- `yarn test` *(fails: MiMC reference found)*

------
https://chatgpt.com/codex/tasks/task_e_684ee9aa64a48327bc334dc6a02a0727