### PR TITLE
Add coverage script

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ See [docs/audit](docs/audit/README.md) for the outline of the upcoming formal au
 
 Run `node scripts/proof_fuzz_harness.js` to generate 1,000 invalid witnesses for every circuit. The script uses `ffmpeg-wasm` to produce random noise and asserts that `snarkjs` rejects each witness. Set `FUZZ_ITERS` to override the iteration count during testing.
 
+## Test Coverage
+
+Run `scripts/collect_coverage.sh` to execute all tests (Solidity, Python and Node) and generate a consolidated `coverage/coverage.lcov` report. The script also executes the `scripts/qv_verifier_e2e.js` end-to-end test which was previously unused.
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/scripts/collect_coverage.sh
+++ b/scripts/collect_coverage.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(git rev-parse --show-toplevel)
+COV_DIR="$ROOT/coverage"
+rm -rf "$COV_DIR"
+mkdir -p "$COV_DIR/node" "$COV_DIR/python"
+
+# Forge coverage
+echo "Running solidity coverage..."
+forge coverage --lcov > "$COV_DIR/forge.lcov"
+
+# Python coverage
+echo "Running backend tests with coverage..."
+pip install --quiet coverage pytest pytest-cov
+pytest packages/backend/tests \
+  --cov=packages/backend \
+  --cov-report=lcov:"$COV_DIR/python/lcov.info"
+
+# Node tests and E2E verifier
+echo "Running node tests with coverage..."
+# npm test already runs various JS tests. We also run the QV verifier e2e script.
+npx -y c8 --reporter=lcov --report-dir="$COV_DIR/node" bash -c "npm test && node scripts/qv_verifier_e2e.js"
+
+# Combine coverage
+cat "$COV_DIR/forge.lcov" "$COV_DIR/python/lcov.info" "$COV_DIR/node/lcov.info" > "$COV_DIR/coverage.lcov"
+
+echo "Combined coverage written to $COV_DIR/coverage.lcov"


### PR DESCRIPTION
## Summary
- add a script to collect coverage from all test suites
- document how to run it in README

## Testing
- `forge coverage --report lcov --ir-minimum` *(fails: stack too deep, killed)*

------
https://chatgpt.com/codex/tasks/task_e_684f001480c88327ad46bd8b9fd4c202