### PR TITLE
Reduce forge coverage memory usage

### DIFF
--- a/scripts/collect_coverage.sh
+++ b/scripts/collect_coverage.sh
@@ -16,7 +16,11 @@ if [ ! -f .env ]; then
 fi
 source .env
 
-forge coverage --report lcov --report-file "$COV_DIR/forge.lcov" -vv
+# The Forge coverage command can consume a significant amount of memory on
+# larger projects. The `--ir-minimum` flag enables minimal IR based
+# optimisations which substantially reduces the memory footprint while still
+# producing an accurate coverage report.
+forge coverage --ir-minimum --report lcov --report-file "$COV_DIR/forge.lcov" -vv
 
 # Python coverage
 echo "Running backend tests with coverage..."


### PR DESCRIPTION
## Summary
- tweak the coverage script to lower forge memory usage

## Testing
- `bash -n scripts/collect_coverage.sh`
- `timeout 10 ./scripts/collect_coverage.sh` *(fails early due to timeout)*

------
https://chatgpt.com/codex/tasks/task_e_684f17ef238c83279fbbf43008f80ff0