### PR TITLE
Improve coverage script to reduce memory usage

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -17,6 +17,10 @@ optimizer = true
 optimizer_runs = 200000
 via_ir = true
 
+[profile.coverage]
+optimizer = false
+via_ir = false
+
 [invariant]
 maxRuns = 50   # default is 2000 - fart emoji
 


### PR DESCRIPTION
## Summary
- add a dedicated `coverage` profile in `foundry.toml` with optimizations disabled
- update `collect_coverage.sh` to run coverage per test file and clean after each run

## Testing
- `forge coverage --ir-minimum --match-path test/EnvLoad.t.sol --report lcov --report-file coverage/env.lcov -vv`
- `forge coverage --ir-minimum --match-path test/DepositManager.t.sol --report lcov --report-file coverage/tmp2.lcov -vv`

------
https://chatgpt.com/codex/tasks/task_e_684f1e632bdc8327a4ca064c4b7db617