### PR TITLE
Fix coverage script

### DIFF
--- a/scripts/collect_coverage.sh
+++ b/scripts/collect_coverage.sh
@@ -24,7 +24,8 @@ export FOUNDRY_PROFILE=coverage
 # larger projects. To keep the memory footprint manageable we run coverage
 # separately for each test file and concatenate the resulting LCOV reports.
 :> "$COV_DIR/forge.lcov"
-for test_file in $(find test -name '*.t.sol'); do
+# Skip expensive invariant test during coverage
+for test_file in $(find test -name '*.t.sol' ! -name 'AuditInvariant.t.sol'); do
     echo "\n--- Running coverage for $test_file ---"
     forge coverage --ir-minimum \
         --match-path "$test_file" \


### PR DESCRIPTION
## Summary
- skip `AuditInvariant.t.sol` in coverage run to avoid timeouts

## Testing
- `bash -n scripts/collect_coverage.sh`
- `npm test`
- `pytest packages/backend/tests -q` *(fails: ModuleNotFoundError: 'jose', 'httpx', 'celery')*

------
https://chatgpt.com/codex/tasks/task_e_684f255b7a308327a403fe1948f48adf