### PR TITLE
Fix coverage script dependency install

### DIFF
--- a/scripts/collect_coverage.sh
+++ b/scripts/collect_coverage.sh
@@ -36,6 +36,7 @@ done
 
 # Python coverage
 echo "Running backend tests with coverage..."
+pip install --quiet -r packages/backend/requirements.txt
 pip install --quiet coverage pytest pytest-cov
 pytest packages/backend/tests \
   --cov=packages/backend \


### PR DESCRIPTION
## Summary
- ensure backend requirements installed for Python coverage

## Testing
- `pip install -r packages/backend/requirements.txt`
- `pytest packages/backend/tests -q` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'redis-server')*


------
https://chatgpt.com/codex/tasks/task_e_684f2a8cdfdc832793e74057638541bf