### PR TITLE
Fix verifier E2E test

### DIFF
--- a/scripts/qv_verifier_e2e.js
+++ b/scripts/qv_verifier_e2e.js
@@ -86,8 +86,10 @@ function run(cmd, args, capture = false) {
     process.exitCode = 1;
   }
 
-  inputs[0] = (BigInt(inputs[0]) + 1n).toString();
-  const bad = await verifier.verifyProof(a, b, c, inputs);
+  // Tamper with the proof to ensure verification fails
+  const badA = [...a];
+  badA[0] = (BigInt(badA[0]) + 1n).toString();
+  const bad = await verifier.verifyProof(badA, b, c, inputs);
   console.log('verifyProof(tampered) =>', bad);
   if (bad) {
     console.error('Tampered proof unexpectedly verified');


### PR DESCRIPTION
## Summary
- modify qv_verifier_e2e.js test to tamper with the proof itself

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68502688a8b083279763b4cb6b6cf208