### PR TITLE
Add GHCR deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,40 @@
+name: Deploy
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      deployments: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build backend image
+        run: docker build -t ghcr.io/${{ github.repository }}/backend -f Dockerfile .
+      - name: Push backend image
+        run: docker push ghcr.io/${{ github.repository }}/backend
+      - name: Build frontend image
+        run: docker build -t ghcr.io/${{ github.repository }}/frontend -f Dockerfile.frontend .
+      - name: Push frontend image
+        run: docker push ghcr.io/${{ github.repository }}/frontend
+      - name: Record deployment
+        uses: chrnorm/deployment-action@v2
+        with:
+          token: ${{ github.token }}
+          environment: production
+          description: Production container build for ${{ github.sha }}


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds backend and frontend Docker images
- push the images to GitHub Container Registry
- record a production deployment event

## Testing
- `npm test`
- `pytest packages/backend/tests`
- `forge test` *(fails: process killed)*

------
https://chatgpt.com/codex/tasks/task_e_68507cf646688327bde9e590426b9efd