### PR TITLE
Fix forge warnings

### DIFF
--- a/script/DeployFactory.s.sol
+++ b/script/DeployFactory.s.sol
@@ -11,10 +11,10 @@ contract UnsafeVerifierStub is Verifier {
     uint256 public immutable allowedChain;
     constructor(uint256 _chain) { allowedChain = _chain; }
     function verifyProof(
-        uint256[2] calldata a,
-        uint256[2][2] calldata b,
-        uint256[2] calldata c,
-        uint256[7] calldata pubSignals
+        uint256[2] calldata /* a */,
+        uint256[2][2] calldata /* b */,
+        uint256[2] calldata /* c */,
+        uint256[7] calldata /* pubSignals */
     ) public view override returns (bool) {
         require(block.chainid == allowedChain, "unsafe verifier");
         return true;

--- a/test/AuditInvariant.t.sol
+++ b/test/AuditInvariant.t.sol
@@ -15,7 +15,7 @@ import {IMACI} from "../contracts/interfaces/IMACI.sol";
 contract TestVerifier is Verifier {
     function verifyProof(uint256[2] calldata, uint256[2][2] calldata, uint256[2] calldata, uint256[7] calldata)
         public
-        view
+        pure
         override
         returns (bool)
     {

--- a/test/ElectionManagerUpgrade.t.sol
+++ b/test/ElectionManagerUpgrade.t.sol
@@ -23,7 +23,7 @@ contract ElectionManagerUpgradeTest is Test {
         manager = ElectionManagerV2(address(proxy));
     }
 
-    function test_Upgrade() public {
+    function test_Upgrade() public view {
         // Placeholder for a real upgrade test
         assertTrue(manager.owner() == owner);
     }

--- a/test/EnvLoad.t.sol
+++ b/test/EnvLoad.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.24;
 import "forge-std/Test.sol";
 
 contract EnvLoad is Test {
-    function testEnvFileIsVisible() public {
+    function testEnvFileIsVisible() public view {
         // The real value is whatever scripts/setup_env.sh wrote.
         // We only care that it’s *defined* and parses as an address.
         address mgr = vm.envAddress("ELECTION_MANAGER");

--- a/test/FuzzAndInvariant.t.sol
+++ b/test/FuzzAndInvariant.t.sol
@@ -13,7 +13,7 @@ contract TestVerifier is Verifier {
         uint256[2][2] calldata,
         uint256[2] calldata,
         uint256[7] calldata
-    ) public view override returns (bool) {
+    ) public pure override returns (bool) {
         return true;
     }
 }

--- a/test/SmartWalletSig.t.sol
+++ b/test/SmartWalletSig.t.sol
@@ -31,7 +31,7 @@ contract SmartWalletSigTest is Test {
         wallet = new SigHelper(EntryPoint(payable(address(0))), ownerAddr);
     }
 
-    function testValidSignature() public {
+    function testValidSignature() public view {
         bytes32 msgHash = keccak256("dummy userOp");
         // FIX: Sign the raw hash, not the EIP-191 prefixed hash.
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(OWNER_KEY, msgHash);
@@ -44,7 +44,7 @@ contract SmartWalletSigTest is Test {
         assertTrue(ok, "correct key should validate");
     }
 
-    function testInvalidSignature() public {
+    function testInvalidSignature() public view {
         bytes32 msgHash = keccak256("dummy userOp");
         // FIX: Sign the raw hash for consistency.
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(0xBEEF, msgHash);
@@ -56,12 +56,12 @@ contract SmartWalletSigTest is Test {
         assertFalse(ok, "wrong key should fail");
     }
 
-    function testValidEdDSA() public {
+    function testValidEdDSA() public view {
         bool ok = wallet.isValid(ED_MSG, ED_SIG);
         assertTrue(ok, "eddsa signature should validate");
     }
 
-    function testInvalidEdDSA() public {
+    function testInvalidEdDSA() public view {
         bytes memory badSig = bytes.concat(ED_SIG, hex"00");
         bool ok = wallet.isValid(ED_MSG, badSig);
         assertFalse(ok, "malformed eddsa should fail");

--- a/test/SmokeTests.t.sol
+++ b/test/SmokeTests.t.sol
@@ -13,7 +13,7 @@ contract TestVerifier is Verifier {
         uint256[2][2] calldata,
         uint256[2] calldata,
         uint256[7] calldata
-    ) public view override returns (bool) {
+    ) public pure override returns (bool) {
         return true;
     }
 }

--- a/test/WalletFactoryDeterminism.t.sol
+++ b/test/WalletFactoryDeterminism.t.sol
@@ -15,7 +15,7 @@ contract TestVerifier is Verifier {
         uint256[2][2] calldata,
         uint256[2] calldata,
         uint256[7] calldata
-    ) public view override returns (bool) {
+    ) public pure override returns (bool) {
         return true;
     }
 }

--- a/test/integration/FullFlow.t.sol
+++ b/test/integration/FullFlow.t.sol
@@ -143,6 +143,7 @@ contract FullFlowTest is Test {
     /// @dev Builds and signs a UserOperation.
     function _buildOp(uint256 eid, uint256 ballotNonce, uint256 vote, bytes memory vcProof)
         internal
+        view
         returns (UserOperation memory op, bytes32 opHash)
     {
         // Populate UserOp using the helper functions

--- a/test/integration/MultiUserFlow.t.sol
+++ b/test/integration/MultiUserFlow.t.sol
@@ -149,7 +149,7 @@ contract MultiUserFlowTest is Test {
         uint256 ballotNonce,
         uint256 vote,
         bytes memory vcProof
-    ) internal returns (UserOperation memory op, bytes32 opHash) {
+    ) internal view returns (UserOperation memory op, bytes32 opHash) {
         op.sender = wallet;
         op.nonce = entryPoint.getNonce(wallet, 0);
         op.initCode = wallet.code.length > 0 ? bytes("") : _buildInitCode(voter);


### PR DESCRIPTION
## Summary
- fix unused parameter warnings in `DeployFactory.s.sol`
- mark test functions as pure/view where possible

## Testing
- `forge build`
- `npm test`
- `pytest -q packages/backend/tests` *(fails: ModuleNotFoundError: No module named 'jose')*

------
https://chatgpt.com/codex/tasks/task_e_68507ebe5ef483279fdfcdf5a3607a2e