### PR TITLE
Add unit tests for core utility contracts

### DIFF
--- a/test/BabyJubjubSig.t.sol
+++ b/test/BabyJubjubSig.t.sol
@@ -1,0 +1,41 @@
+// test/BabyJubjubSig.t.sol
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import "../contracts/lib/BabyJubjubSig.sol";
+
+contract BabyJubjubSigTest is Test {
+    function _buildSig(bytes32 digest, address owner) internal pure returns (bytes memory) {
+        bytes32 r8x = digest;
+        bytes32 r8y = sha256(abi.encodePacked(bytes20(owner), digest));
+        bytes32 s = sha256(abi.encodePacked(digest, bytes20(owner)));
+        return abi.encodePacked(r8x, r8y, s);
+    }
+
+    function testVerifyValidSignature() public {
+        bytes32 digest = keccak256("msg");
+        address owner = address(0x1234);
+        bytes memory sig = _buildSig(digest, owner);
+        bool ok = BabyJubjubSig.verify(digest, sig, owner);
+        assertTrue(ok, "valid signature should verify");
+    }
+
+    function testVerifyRejectsBadLength() public {
+        bytes32 digest = keccak256("msg");
+        address owner = address(0x1234);
+        bytes memory sig = hex"deadbeef"; // length != 96
+        bool ok = BabyJubjubSig.verify(digest, sig, owner);
+        assertFalse(ok, "wrong length should fail");
+    }
+
+    function testVerifyRejectsWrongComponents() public {
+        bytes32 digest = keccak256("msg");
+        address owner = address(0x1234);
+        bytes memory sig = _buildSig(digest, owner);
+        // Flip last byte to invalidate s component
+        sig[95] = bytes1(uint8(sig[95]) ^ 0x01);
+        bool ok = BabyJubjubSig.verify(digest, sig, owner);
+        assertFalse(ok, "modified signature should fail");
+    }
+}

--- a/test/OwnableUpgradeable.t.sol
+++ b/test/OwnableUpgradeable.t.sol
@@ -1,0 +1,57 @@
+// test/OwnableUpgradeable.t.sol
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import "../contracts/utils/OwnableUpgradeable.sol";
+
+contract OwnableMock is OwnableUpgradeable {
+    function initialize(address owner_) external initializer {
+        __Ownable_init(owner_);
+    }
+
+    function onlyOwnerFn() external view onlyOwner returns (bool) {
+        return true;
+    }
+}
+
+contract OwnableUpgradeableTest is Test {
+    OwnableMock mock;
+    address owner = address(this);
+    address other = address(0xBEEF);
+
+    function setUp() public {
+        mock = new OwnableMock();
+        mock.initialize(owner);
+    }
+
+    function testInitialOwner() public {
+        assertEq(mock.owner(), owner);
+    }
+
+    function testOnlyOwnerModifier() public {
+        bool ok = mock.onlyOwnerFn();
+        assertTrue(ok);
+        vm.prank(other);
+        vm.expectRevert("Ownable: caller is not the owner");
+        mock.onlyOwnerFn();
+    }
+
+    function testTransferOwnership() public {
+        vm.expectEmit(true, true, false, true);
+        emit OwnableUpgradeable.OwnershipTransferred(owner, other);
+        mock.transferOwnership(other);
+        assertEq(mock.owner(), other);
+    }
+
+    function testTransferOwnershipOnlyOwner() public {
+        vm.prank(other);
+        vm.expectRevert("Ownable: caller is not the owner");
+        mock.transferOwnership(address(1));
+    }
+
+    function testTransferOwnershipZeroAddress() public {
+        vm.expectRevert("Ownable: new owner is the zero address");
+        mock.transferOwnership(address(0));
+    }
+}

--- a/test/QuadraticVotingStrategy.t.sol
+++ b/test/QuadraticVotingStrategy.t.sol
@@ -1,0 +1,68 @@
+// test/QuadraticVotingStrategy.t.sol
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import "../contracts/strategies/QuadraticVotingStrategy.sol";
+import "../contracts/TallyVerifier.sol";
+
+contract GoodVerifier is TallyVerifier {
+    function verifyProof(uint256[2] calldata, uint256[2][2] calldata, uint256[2] calldata, uint256[7] calldata)
+        public
+        pure
+        override
+        returns (bool)
+    {
+        return true;
+    }
+}
+
+contract BadVerifier is TallyVerifier {
+    function verifyProof(uint256[2] calldata, uint256[2][2] calldata, uint256[2] calldata, uint256[7] calldata)
+        public
+        pure
+        override
+        returns (bool)
+    {
+        return false;
+    }
+}
+
+contract QuadraticVotingStrategyTest is Test {
+    QuadraticVotingStrategy strategy;
+
+    function setUp() public {
+        strategy = new QuadraticVotingStrategy(new GoodVerifier());
+    }
+
+    function testTallyReturnsSignals() public {
+        uint256[2] memory a;
+        uint256[2][2] memory b;
+        uint256[2] memory c;
+        uint256[] memory inputs = new uint256[](7);
+        inputs[0] = 11;
+        inputs[1] = 22;
+        uint256[2] memory tally = strategy.tallyVotes(a, b, c, inputs);
+        assertEq(tally[0], 11);
+        assertEq(tally[1], 22);
+    }
+
+    function testTallyBadLength() public {
+        uint256[2] memory a;
+        uint256[2][2] memory b;
+        uint256[2] memory c;
+        uint256[] memory inputs = new uint256[](6);
+        vm.expectRevert("bad-len");
+        strategy.tallyVotes(a, b, c, inputs);
+    }
+
+    function testTallyVerifierFailure() public {
+        strategy = new QuadraticVotingStrategy(new BadVerifier());
+        uint256[2] memory a;
+        uint256[2][2] memory b;
+        uint256[2] memory c;
+        uint256[] memory inputs = new uint256[](7);
+        vm.expectRevert("invalid tally proof");
+        strategy.tallyVotes(a, b, c, inputs);
+    }
+}


### PR DESCRIPTION
## Summary
- cover BabyJubjubSig library
- test QuadraticVotingStrategy behaviour
- add suite for OwnableUpgradeable helper

## Testing
- `forge test --match-contract BabyJubjubSigTest -vvv`
- `forge test --match-contract QuadraticVotingStrategyTest -vvv`
- `forge test --match-contract OwnableUpgradeableTest -vvv`


------
https://chatgpt.com/codex/tasks/task_e_685080a119288327b75e822d1c6f4b55