### PR TITLE
Add coverage tests

### DIFF
--- a/test/TallyVerifier.t.sol
+++ b/test/TallyVerifier.t.sol
@@ -1,0 +1,23 @@
+// test/TallyVerifier.t.sol
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {TallyVerifier} from "../contracts/TallyVerifier.sol";
+
+contract TallyVerifierTest is Test {
+    TallyVerifier verifier;
+
+    function setUp() public {
+        verifier = new TallyVerifier();
+    }
+
+    function testVerifyProofAlwaysTrue() public {
+        uint256[2] memory a;
+        uint256[2][2] memory b;
+        uint256[2] memory c;
+        uint256[7] memory inputs;
+        bool ok = verifier.verifyProof(a, b, c, inputs);
+        assertTrue(ok, "stub verifier should return true");
+    }
+}

--- a/test/TotingDAOParams.t.sol
+++ b/test/TotingDAOParams.t.sol
@@ -1,0 +1,23 @@
+// test/TotingDAOParams.t.sol
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {TotingToken} from "../contracts/TotingToken.sol";
+import {TotingDAO} from "../contracts/TotingDAO.sol";
+import {TimelockController} from "@openzeppelin/contracts/governance/TimelockController.sol";
+
+contract TotingDAOParamsTest is Test {
+    TotingDAO dao;
+
+    function setUp() public {
+        TotingToken token = new TotingToken();
+        TimelockController timelock = new TimelockController(0, new address[](0), new address[](0), address(this));
+        dao = new TotingDAO(token, timelock);
+    }
+
+    function testParameters() public {
+        assertEq(dao.votingDelay(), 1);
+        assertEq(dao.votingPeriod(), 45818);
+    }
+}

--- a/test/TotingTokenMint.t.sol
+++ b/test/TotingTokenMint.t.sol
@@ -1,0 +1,26 @@
+// test/TotingTokenMint.t.sol
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {TotingToken} from "../contracts/TotingToken.sol";
+
+contract TotingTokenMintTest is Test {
+    TotingToken token;
+
+    function setUp() public {
+        token = new TotingToken();
+    }
+
+    function testMintAndDelegate() public {
+        token.mint(address(this), 1 ether);
+        assertEq(token.totalSupply(), 1 ether, "mint should increase supply");
+
+        token.delegate(address(this));
+        assertEq(token.getVotes(address(this)), 1 ether, "delegated votes");
+
+        token.transfer(address(1), 0.4 ether);
+        assertEq(token.balanceOf(address(1)), 0.4 ether, "recipient balance");
+        assertEq(token.getVotes(address(this)), 0.6 ether, "votes updated after transfer");
+    }
+}

--- a/test/VerifierBLS.t.sol
+++ b/test/VerifierBLS.t.sol
@@ -1,0 +1,23 @@
+// test/VerifierBLS.t.sol
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {VerifierBLS} from "../contracts/VerifierBLS.sol";
+
+contract VerifierBLSTest is Test {
+    VerifierBLS verifier;
+
+    function setUp() public {
+        verifier = new VerifierBLS();
+    }
+
+    function testVerifyProofAlwaysTrue() public {
+        uint256[2] memory a;
+        uint256[2][2] memory b;
+        uint256[2] memory c;
+        uint256[7] memory inputs;
+        bool ok = verifier.verifyProof(a, b, c, inputs);
+        assertTrue(ok, "stub verifier should return true");
+    }
+}

--- a/test/VerifyingPaymaster.t.sol
+++ b/test/VerifyingPaymaster.t.sol
@@ -1,0 +1,55 @@
+// test/VerifyingPaymaster.t.sol
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {EntryPoint} from "@account-abstraction/contracts/core/EntryPoint.sol";
+import {IPaymaster} from "@account-abstraction/contracts/interfaces/IPaymaster.sol";
+import {VerifyingPaymaster} from "../contracts/VerifyingPaymaster.sol";
+
+contract VerifyingPaymasterHarness is VerifyingPaymaster {
+    constructor(EntryPoint ep, address signer) VerifyingPaymaster(ep, signer) {}
+
+    function callPostOp(IPaymaster.PostOpMode mode, bytes calldata context, uint256 cost) external {
+        _postOp(mode, context, cost);
+    }
+}
+
+contract VerifyingPaymasterTest is Test {
+    EntryPoint ep;
+    VerifyingPaymasterHarness paymaster;
+    address signer = vm.addr(100);
+
+    function setUp() public {
+        ep = new EntryPoint();
+        paymaster = new VerifyingPaymasterHarness(ep, signer);
+    }
+
+    function testDepositAndPostOp() public {
+        uint256 eid = 1;
+        paymaster.deposit{value: 1 ether}(eid);
+        (address sponsor, uint256 amount) = paymaster.sponsorDeposits(eid);
+        assertEq(sponsor, address(this));
+        assertEq(amount, 1 ether);
+        bytes memory ctx = abi.encode(eid);
+        paymaster.callPostOp(IPaymaster.PostOpMode.opSucceeded, ctx, 0.3 ether);
+        (, uint256 remaining) = paymaster.sponsorDeposits(eid);
+        assertEq(remaining, 0.7 ether);
+    }
+
+    function testParseFunctions() public {
+        uint48 validUntil = 10;
+        uint48 validAfter = 5;
+        bytes memory sig = hex"deadbeef";
+        bytes memory pad = abi.encodePacked(address(paymaster), abi.encode(validUntil, validAfter), sig);
+        (uint48 u, uint48 a, bytes memory s) = paymaster.parsePaymasterAndData(pad);
+        assertEq(u, validUntil);
+        assertEq(a, validAfter);
+        assertEq(s, sig);
+
+        uint256 id = 42;
+        bytes memory callData = abi.encodeWithSelector(bytes4(0x12345678), id);
+        uint256 parsed = paymaster.parseElectionId(callData);
+        assertEq(parsed, id);
+    }
+}

--- a/test/WalletFactoryCreateAccount.t.sol
+++ b/test/WalletFactoryCreateAccount.t.sol
@@ -1,0 +1,38 @@
+// test/WalletFactoryCreateAccount.t.sol
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {EntryPoint} from "@account-abstraction/contracts/core/EntryPoint.sol";
+import {WalletFactory} from "../contracts/WalletFactory.sol";
+import {Verifier} from "../contracts/Verifier.sol";
+
+contract TestVerifierWF is Verifier {
+    function verifyProof(uint256[2] calldata, uint256[2][2] calldata, uint256[2] calldata, uint256[7] calldata) public pure override returns (bool) {
+        return true;
+    }
+}
+
+contract WalletFactoryCreateAccountTest is Test {
+    WalletFactory factory;
+    EntryPoint ep;
+    TestVerifierWF verifier;
+    address owner = vm.addr(1);
+
+    function setUp() public {
+        ep = new EntryPoint();
+        verifier = new TestVerifierWF();
+        factory = new WalletFactory(ep, verifier, "bn254");
+    }
+
+    function testCreateAccount() public {
+        uint256[2] memory a;
+        uint256[2][2] memory b;
+        uint256[2] memory c;
+        uint256[7] memory inputs;
+        uint256 salt = 77;
+        bytes memory data = abi.encode(a, b, c, inputs, owner, salt);
+        address wallet = factory.createAccount(data);
+        assertEq(wallet, factory.walletOf(owner));
+    }
+}


### PR DESCRIPTION
## Summary
- add basic unit tests for stub verifiers
- test minting and delegation for the governance token
- verify DAO configuration values
- cover deposit logic and helpers of VerifyingPaymaster
- test WalletFactory `createAccount`

## Testing
- `forge test --match-contract TallyVerifierTest -vvv`
- `forge test --match-contract TotingTokenMintTest -vvv`
- `forge test --match-contract TotingDAOParamsTest -vvv`
- `forge test --match-contract VerifierBLSTest -vvv`
- `forge test --match-contract VerifyingPaymasterTest -vvv`
- `forge test --match-contract WalletFactoryCreateAccountTest -vvv`


------
https://chatgpt.com/codex/tasks/task_e_6850806d5ce883278b3eadd2c21247e2