### PR TITLE
Add tests for core contracts

### DIFF
--- a/test/MockMACI.t.sol
+++ b/test/MockMACI.t.sol
@@ -1,0 +1,21 @@
+// test/MockMACI.t.sol
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {MockMACI} from "../contracts/MockMACI.sol";
+
+contract MockMACITest is Test {
+    MockMACI maci;
+
+    function setUp() public {
+        maci = new MockMACI();
+    }
+
+    function testPublishMessageEmitsEvent() public {
+        bytes memory data = hex"deadbeef";
+        vm.expectEmit(false, false, false, true);
+        emit MockMACI.Message(data);
+        maci.publishMessage(data);
+    }
+}

--- a/test/ParticipationBadge.t.sol
+++ b/test/ParticipationBadge.t.sol
@@ -28,4 +28,15 @@ contract ParticipationBadgeTest is Test {
         vm.expectRevert("Ownable: caller is not the owner");
         badge.safeMint(address(1), 1);
     }
+
+    function testMintEmitsEventAndIncrementsId() public {
+        vm.prank(manager);
+        vm.expectEmit(true, true, true, false);
+        emit ParticipationBadge.BadgeMinted(address(1), 0, 42);
+        uint256 id1 = badge.safeMint(address(1), 42);
+        assertEq(id1, 0);
+        vm.prank(manager);
+        uint256 id2 = badge.safeMint(address(2), 43);
+        assertEq(id2, 1);
+    }
 }

--- a/test/QVManager.t.sol
+++ b/test/QVManager.t.sol
@@ -15,6 +15,17 @@ contract QVVerifierStub is QVVerifier {
     }
 }
 
+contract QVVerifierFalse is QVVerifier {
+    function verifyProof(
+        uint256[2] calldata,
+        uint256[2][2] calldata,
+        uint256[2] calldata,
+        uint256[7] calldata
+    ) public pure override returns (bool) {
+        return false;
+    }
+}
+
 contract MACIStub is IMACI {
     event Message(bytes data);
     function publishMessage(bytes calldata data) external override {
@@ -41,5 +52,28 @@ contract QVManagerTest is Test {
         bytes memory ballot = hex"deadbeef";
 
         manager.submitBallot(a, b, c, inputs, ballot);
+    }
+
+    function testDuplicateBallotReverts() public {
+        uint256[2] memory a;
+        uint256[2][2] memory b;
+        uint256[2] memory c;
+        uint256[7] memory inputs;
+        bytes memory ballot = hex"deadbeef";
+        manager.submitBallot(a, b, c, inputs, ballot);
+        vm.expectRevert("duplicate ballot");
+        manager.submitBallot(a, b, c, inputs, ballot);
+    }
+
+    function testSubmitBallotInvalidProofReverts() public {
+        uint256[2] memory a;
+        uint256[2][2] memory b;
+        uint256[2] memory c;
+        uint256[7] memory inputs;
+        bytes memory ballot = hex"deadbeef";
+        QVVerifierFalse bad = new QVVerifierFalse();
+        QVManager mgr = new QVManager(IMACI(maci), QVVerifier(address(bad)));
+        vm.expectRevert("invalid voice credit proof");
+        mgr.submitBallot(a, b, c, inputs, ballot);
     }
 }

--- a/test/QVManagerTyped.t.sol
+++ b/test/QVManagerTyped.t.sol
@@ -53,4 +53,20 @@ contract QVManagerTypedTest is Test {
         vm.prank(vm.addr(1));
         manager.submitTypedBallot(a, b, c, inputs, ballot, sig);
     }
+
+    function testTypedBallotBadSigReverts() public {
+        uint256[2] memory a;
+        uint256[2][2] memory b;
+        uint256[2] memory c;
+        uint256[7] memory inputs;
+        bytes memory ballot = hex"deadbeef";
+        bytes32 digest = manager.hashTypedDataV4(
+            keccak256(abi.encode(keccak256("Ballot(address voter, bytes32 ballotHash)"), vm.addr(1), keccak256(ballot)))
+        );
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(2, digest);
+        bytes memory sig = abi.encodePacked(r, s, v);
+        vm.prank(vm.addr(1));
+        vm.expectRevert("bad sig");
+        manager.submitTypedBallot(a, b, c, inputs, ballot, sig);
+    }
 }

--- a/test/QVVerifier.t.sol
+++ b/test/QVVerifier.t.sol
@@ -1,0 +1,23 @@
+// test/QVVerifier.t.sol
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {QVVerifier} from "../contracts/QVVerifier.sol";
+
+contract QVVerifierTest is Test {
+    QVVerifier verifier;
+
+    function setUp() public {
+        verifier = new QVVerifier();
+    }
+
+    function testVerifyProofAlwaysReturnsTrue() public {
+        uint256[2] memory a;
+        uint256[2][2] memory b;
+        uint256[2] memory c;
+        uint256[7] memory inputs;
+        bool ok = verifier.verifyProof(a, b, c, inputs);
+        assertTrue(ok);
+    }
+}

--- a/test/SmartWallet.t.sol
+++ b/test/SmartWallet.t.sol
@@ -1,0 +1,63 @@
+// test/SmartWallet.t.sol
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {SmartWallet} from "../contracts/SmartWallet.sol";
+import {EntryPoint} from "@account-abstraction/contracts/core/EntryPoint.sol";
+
+contract DummyTarget {
+    bool public pinged;
+
+    function ping() external {
+        pinged = true;
+    }
+}
+
+contract SmartWalletTest is Test {
+    SmartWallet wallet;
+    EntryPoint ep;
+    address owner = address(0xABCD);
+    address other = address(0xBEEF);
+
+    function setUp() public {
+        ep = new EntryPoint();
+        wallet = new SmartWallet(ep, owner);
+    }
+
+    function testExecuteByOwner() public {
+        DummyTarget target = new DummyTarget();
+        vm.prank(owner);
+        wallet.execute(address(target), 0, abi.encodeCall(DummyTarget.ping, ()));
+        assertTrue(target.pinged());
+    }
+
+    function testExecuteByEntryPoint() public {
+        DummyTarget target = new DummyTarget();
+        vm.prank(address(ep));
+        wallet.execute(address(target), 0, abi.encodeCall(DummyTarget.ping, ()));
+        assertTrue(target.pinged());
+    }
+
+    function testExecuteUnauthorizedReverts() public {
+        DummyTarget target = new DummyTarget();
+        vm.prank(other);
+        vm.expectRevert("SmartWallet: not authorized");
+        wallet.execute(address(target), 0, abi.encodeCall(DummyTarget.ping, ()));
+    }
+
+    function testExecuteBatch() public {
+        DummyTarget t1 = new DummyTarget();
+        DummyTarget t2 = new DummyTarget();
+        address[] memory dest = new address[](2);
+        dest[0] = address(t1);
+        dest[1] = address(t2);
+        uint256[] memory val = new uint256[](2);
+        bytes[] memory data = new bytes[](2);
+        data[0] = abi.encodeCall(DummyTarget.ping, ());
+        data[1] = abi.encodeCall(DummyTarget.ping, ());
+        vm.prank(owner);
+        wallet.executeBatch(dest, val, data);
+        assertTrue(t1.pinged() && t2.pinged());
+    }
+}


### PR DESCRIPTION
## Summary
- increase unit test coverage for MACI manager and wallet logic
- cover ParticipationBadge minting and duplicate ballot checks
- add typed ballot failure cases
- add simple tests for MockMACI and QVVerifier stubs
- validate SmartWallet execution permissions

## Testing
- `forge test --match-contract SmartWalletTest -v`
- `forge test --match-contract MockMACITest -v`
- `forge test --match-contract QVVerifierTest -v`
- `forge test --match-contract ParticipationBadgeTest -v`
- `forge test --match-contract QVManagerTest -v`
- `forge test --match-contract QVManagerTypedTest -v`


------
https://chatgpt.com/codex/tasks/task_e_68508061027c8327adbd3bddaf4df0a6