### PR TITLE
Add coverage tests for election managers and verifier

### DIFF
--- a/test/DepositVerifier.t.sol
+++ b/test/DepositVerifier.t.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import "../contracts/DepositManager.sol";
+import "../contracts/DepositVerifier.sol";
+
+contract DepositVerifierTest is Test {
+    DepositManager manager;
+
+    function setUp() public {
+        // Use real verifier which will reject the dummy proof
+        DepositVerifier verifier = new DepositVerifier();
+        manager = new DepositManager(verifier);
+    }
+
+    function testInvalidProofReverts() public {
+        uint256[2] memory a;
+        uint256[2][2] memory b;
+        uint256[2] memory c;
+        uint256[2] memory inputs;
+        // Call deposit with all zero proof which should fail verification
+        vm.expectRevert("invalid-proof");
+        manager.deposit(a, b, c, inputs);
+    }
+
+    function testVerifierReturnsFalse() public view {
+        DepositVerifier verifier = manager.verifier();
+        uint256[2] memory a;
+        uint256[2][2] memory b;
+        uint256[2] memory c;
+        uint256[2] memory inputs;
+        bool ok = verifier.verifyProof(a, b, c, inputs);
+        assertFalse(ok, "zero proof should fail");
+    }
+}

--- a/test/ElectionManagerBasic.t.sol
+++ b/test/ElectionManagerBasic.t.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import "../contracts/ElectionManager.sol";
+import "../contracts/MockMACI.sol";
+import "../contracts/TallyVerifier.sol";
+
+contract EligibilityStub is IEligibilityVerifier {
+    function isEligible(address) external pure returns (bool) { return true; }
+}
+
+contract ElectionManagerBasicTest is Test {
+    ElectionManager manager;
+    MockMACI maci;
+
+    function setUp() public {
+        maci = new MockMACI();
+        manager = new ElectionManager(IMACI(address(maci)));
+        // set tally verifier to always-true stub
+        TallyVerifier verifier = new TallyVerifier();
+        vm.store(
+            address(manager),
+            bytes32(uint256(0)),
+            bytes32(uint256(uint160(address(verifier))))
+        );
+    }
+
+    function testCreateAndTally() public {
+        EligibilityStub ev = new EligibilityStub();
+        vm.expectEmit(true, true, true, true);
+        emit ElectionCreated(0, bytes32(uint256(1)), address(ev));
+        manager.createElection(bytes32(uint256(1)), ev);
+
+        // enqueue a message during the election
+        vm.expectEmit(false, false, false, true, address(maci));
+        emit Message(abi.encode(address(this), uint256(1), uint256(0), new bytes(0)));
+        manager.enqueueMessage(0, 1, 0, new bytes(0));
+
+        // fast forward to after election end
+        (, uint256 end,) = manager.elections(0);
+        vm.roll(end + 1);
+
+        uint256[2] memory a; uint256[2][2] memory b; uint256[2] memory c; uint256[7] memory inputs;
+        inputs[0] = 5; inputs[1] = 6;
+        vm.expectEmit(true, true, true, true);
+        emit Tally(0, 5, 6);
+        manager.tallyVotes(0, a, b, c, inputs);
+        bool tallied = manager.tallies(0);
+        assertTrue(tallied);
+    }
+
+    event Message(bytes data);
+    event ElectionCreated(uint id, bytes32 indexed meta, address verifier);
+    event Tally(uint256 id, uint256 A, uint256 B);
+}

--- a/test/ElectionManagerV2Basic.t.sol
+++ b/test/ElectionManagerV2Basic.t.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import {ElectionManagerV2} from "../contracts/ElectionManagerV2.sol";
+import {MockMACI} from "../contracts/MockMACI.sol";
+import {IVotingStrategy} from "../contracts/interfaces/IVotingStrategy.sol";
+import {IMACI} from "../contracts/interfaces/IMACI.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+
+contract DummyStrategy is IVotingStrategy {
+    function tallyVotes(
+        uint256[2] calldata,
+        uint256[2][2] calldata,
+        uint256[2] calldata,
+        uint256[] calldata
+    ) external pure returns (uint256[2] memory tally) {
+        tally[0] = 7;
+        tally[1] = 9;
+    }
+}
+
+contract ElectionManagerV2BasicTest is Test {
+    ElectionManagerV2 manager;
+    MockMACI maci;
+    address owner = address(this);
+
+    function setUp() public {
+        maci = new MockMACI();
+        ElectionManagerV2 impl = new ElectionManagerV2();
+        bytes memory data = abi.encodeCall(ElectionManagerV2.initialize, (IMACI(address(maci)), owner));
+        ERC1967Proxy proxy = new ERC1967Proxy(address(impl), data);
+        manager = ElectionManagerV2(address(proxy));
+    }
+
+    function testFullFlow() public {
+        DummyStrategy strategy = new DummyStrategy();
+        vm.prank(owner);
+        manager.createElection(bytes32(uint256(1)), strategy);
+        uint256 id = 0;
+        address voter = address(0xBEEF);
+        vm.prank(voter);
+        manager.enqueueMessage(id, 2, 0, "");
+        address badgeAddr = address(manager.badge());
+        assertEq(ERC721(badgeAddr).balanceOf(voter), 1);
+        (,uint128 end) = manager.elections(id);
+        uint256[2] memory a; uint256[2][2] memory b; uint256[2] memory c; uint256[7] memory inputs;
+        vm.roll(end + 1);
+        manager.tallyVotes(id, a, b, c, inputs);
+        bool tallied = manager.tallies(id);
+        assertTrue(tallied);
+        assertEq(manager.result(0), 7);
+        assertEq(manager.result(1), 9);
+    }
+
+}


### PR DESCRIPTION
## Summary
- add direct tests for DepositVerifier and failure case
- add ElectionManager basic test for creating and tallying an election
- add ElectionManagerV2 basic flow including badge mint and tally

## Testing
- `forge test --match-contract DepositVerifierTest -vvv`
- `forge test --match-contract ElectionManagerBasicTest -vvv`
- `forge test --match-contract ElectionManagerV2BasicTest -vvv`
- `forge test --match-contract DepositManagerTest -vvv`


------
https://chatgpt.com/codex/tasks/task_e_6850804327c08327bdf1f13b9cab74ba