### PR TITLE
Fix mutability warnings in tests

### DIFF
--- a/test/BabyJubjubSig.t.sol
+++ b/test/BabyJubjubSig.t.sol
@@ -13,7 +13,7 @@ contract BabyJubjubSigTest is Test {
         return abi.encodePacked(r8x, r8y, s);
     }
 
-    function testVerifyValidSignature() public {
+    function testVerifyValidSignature() public pure {
         bytes32 digest = keccak256("msg");
         address owner = address(0x1234);
         bytes memory sig = _buildSig(digest, owner);
@@ -21,7 +21,7 @@ contract BabyJubjubSigTest is Test {
         assertTrue(ok, "valid signature should verify");
     }
 
-    function testVerifyRejectsBadLength() public {
+    function testVerifyRejectsBadLength() public pure {
         bytes32 digest = keccak256("msg");
         address owner = address(0x1234);
         bytes memory sig = hex"deadbeef"; // length != 96
@@ -29,7 +29,7 @@ contract BabyJubjubSigTest is Test {
         assertFalse(ok, "wrong length should fail");
     }
 
-    function testVerifyRejectsWrongComponents() public {
+    function testVerifyRejectsWrongComponents() public pure {
         bytes32 digest = keccak256("msg");
         address owner = address(0x1234);
         bytes memory sig = _buildSig(digest, owner);

--- a/test/OwnableUpgradeable.t.sol
+++ b/test/OwnableUpgradeable.t.sol
@@ -25,7 +25,7 @@ contract OwnableUpgradeableTest is Test {
         mock.initialize(owner);
     }
 
-    function testInitialOwner() public {
+    function testInitialOwner() public view {
         assertEq(mock.owner(), owner);
     }
 

--- a/test/QVVerifier.t.sol
+++ b/test/QVVerifier.t.sol
@@ -12,7 +12,7 @@ contract QVVerifierTest is Test {
         verifier = new QVVerifier();
     }
 
-    function testVerifyProofAlwaysReturnsTrue() public {
+    function testVerifyProofAlwaysReturnsTrue() public view {
         uint256[2] memory a;
         uint256[2][2] memory b;
         uint256[2] memory c;

--- a/test/QuadraticVotingStrategy.t.sol
+++ b/test/QuadraticVotingStrategy.t.sol
@@ -35,7 +35,7 @@ contract QuadraticVotingStrategyTest is Test {
         strategy = new QuadraticVotingStrategy(new GoodVerifier());
     }
 
-    function testTallyReturnsSignals() public {
+    function testTallyReturnsSignals() public view {
         uint256[2] memory a;
         uint256[2][2] memory b;
         uint256[2] memory c;

--- a/test/TallyVerifier.t.sol
+++ b/test/TallyVerifier.t.sol
@@ -12,7 +12,7 @@ contract TallyVerifierTest is Test {
         verifier = new TallyVerifier();
     }
 
-    function testVerifyProofAlwaysTrue() public {
+    function testVerifyProofAlwaysTrue() public view {
         uint256[2] memory a;
         uint256[2][2] memory b;
         uint256[2] memory c;

--- a/test/TotingDAOParams.t.sol
+++ b/test/TotingDAOParams.t.sol
@@ -16,7 +16,7 @@ contract TotingDAOParamsTest is Test {
         dao = new TotingDAO(token, timelock);
     }
 
-    function testParameters() public {
+    function testParameters() public view {
         assertEq(dao.votingDelay(), 1);
         assertEq(dao.votingPeriod(), 45818);
     }

--- a/test/VerifierBLS.t.sol
+++ b/test/VerifierBLS.t.sol
@@ -12,7 +12,7 @@ contract VerifierBLSTest is Test {
         verifier = new VerifierBLS();
     }
 
-    function testVerifyProofAlwaysTrue() public {
+    function testVerifyProofAlwaysTrue() public view {
         uint256[2] memory a;
         uint256[2][2] memory b;
         uint256[2] memory c;

--- a/test/VerifyingPaymaster.t.sol
+++ b/test/VerifyingPaymaster.t.sol
@@ -37,7 +37,7 @@ contract VerifyingPaymasterTest is Test {
         assertEq(remaining, 0.7 ether);
     }
 
-    function testParseFunctions() public {
+    function testParseFunctions() public view {
         uint48 validUntil = 10;
         uint48 validAfter = 5;
         bytes memory sig = hex"deadbeef";


### PR DESCRIPTION
## Summary
- mark test functions as `view` or `pure` to eliminate solc mutability warnings

## Testing
- `forge build`
- `forge test --match-path test/BabyJubjubSig.t.sol`
- `forge test --match-path test/OwnableUpgradeable.t.sol`
- `forge test --match-path test/QVVerifier.t.sol`
- `forge test --match-path test/QuadraticVotingStrategy.t.sol`
- `forge test --match-path test/TallyVerifier.t.sol`
- `forge test --match-path test/TotingDAOParams.t.sol`
- `forge test --match-path test/VerifierBLS.t.sol`
- `forge test --match-path test/VerifyingPaymaster.t.sol`


------
https://chatgpt.com/codex/tasks/task_e_685084bd84d0832783682493e5002db5