### PR TITLE
Improve IPFS hash validation

### DIFF
--- a/packages/backend/main.py
+++ b/packages/backend/main.py
@@ -525,6 +525,9 @@ def get_election_metadata(election_id: int, db: Session = Depends(get_db)):
         raise HTTPException(404, "metadata for election not found")
     try:
         cid = cid_from_meta_hash(election.meta)
+    except ValueError:
+        raise HTTPException(400, "invalid metadata hash")
+    try:
         return fetch_json(cid)
     except Exception as e:
         raise HTTPException(500, f"failed to fetch metadata: {e}")

--- a/packages/backend/tests/test_ipfs_utils.py
+++ b/packages/backend/tests/test_ipfs_utils.py
@@ -42,6 +42,11 @@ def test_cid_from_meta_hash():
     assert cid == expected
 
 
+def test_cid_from_meta_hash_invalid():
+    with pytest.raises(ValueError):
+        ipfs.cid_from_meta_hash("0xzzzz")
+
+
 def test_fetch_json(monkeypatch):
     def mock_get(url, timeout):
         class R:

--- a/packages/backend/tests/test_main.py
+++ b/packages/backend/tests/test_main.py
@@ -421,6 +421,16 @@ def test_get_election_not_found():
     assert r.status_code == 404
 
 
+def test_election_meta_bad_hash():
+    db = SessionLocal()
+    election = db.query(Election).get(1)
+    election.meta = "0xzz"
+    db.commit()
+    db.close()
+    r = client.get("/elections/1/meta")
+    assert r.status_code == 400
+
+
 def test_proof_requires_authentication():
     r = client.post("/api/zk/eligibility", json={"foo": "bar"})
     assert r.status_code == 401

--- a/packages/backend/utils/ipfs.py
+++ b/packages/backend/utils/ipfs.py
@@ -34,7 +34,10 @@ def cid_from_meta_hash(meta_hex: str) -> str:
     """Derive an IPFS CID from a hex-encoded sha256 digest."""
     if meta_hex.startswith("0x"):
         meta_hex = meta_hex[2:]
-    digest = bytes.fromhex(meta_hex)
+    try:
+        digest = bytes.fromhex(meta_hex)
+    except ValueError as exc:
+        raise ValueError("invalid metadata hash") from exc
     return b58encode(b"\x12\x20" + digest).decode()
 
 


### PR DESCRIPTION
## Summary
- validate hex string in `cid_from_meta_hash`
- surface invalid hash with HTTP 400 on `/elections/{id}/meta`
- cover new behaviour in tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68578c2fe7d48327a1ba3e3bfd22f26c