### PR TITLE
Refactor post_proof_generic to async

### DIFF
--- a/packages/backend/main.py
+++ b/packages/backend/main.py
@@ -590,7 +590,7 @@ async def paymaster_data(user_op: dict):
 
 
 @app.post("/api/zk/{circuit}")
-def post_proof_generic(
+async def post_proof_generic(
     circuit: str,
     request: Request,
     db: Session = Depends(get_db),
@@ -605,7 +605,7 @@ def post_proof_generic(
     curve = x_curve.lower() if x_curve else "bn254"
     
     try:
-        payload = asyncio.run(request.json())
+        payload = await request.json()
     except json.JSONDecodeError:
         raise HTTPException(status_code=400, detail="Invalid JSON payload")
 


### PR DESCRIPTION
## Summary
- refactor `/api/zk/{circuit}` endpoint to `async def`
- parse request JSON using `await` instead of `asyncio.run`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68578c2ff9e48327bd81d733d15513bc